### PR TITLE
[build] Update controller-gen to v0.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/config/crd/bases/cicd.tmax.io_integrationconfigs.yaml
+++ b/config/crd/bases/cicd.tmax.io_integrationconfigs.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: integrationconfigs.cicd.tmax.io
 spec:
@@ -15,3754 +15,3810 @@ spec:
     plural: integrationconfigs
     singular: integrationconfig
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: IntegrationConfig is the Schema for the integrationconfigs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IntegrationConfigSpec defines the desired state of IntegrationConfig
-          properties:
-            git:
-              description: Git config for target repository
-              properties:
-                apiUrl:
-                  description: ApiUrl for api server (e.g., https://api.github.com
-                    for github type), for the case where the git repository is self-hosted
-                  type: string
-                repository:
-                  description: Repository name of git repository (in <org>/<repo>
-                    form, e.g., tmax-cloud/cicd-operator)
-                  pattern: .+/.+
-                  type: string
-                token:
-                  description: Token
-                  properties:
-                    value:
-                      description: Value is un-encrypted plain string of git token,
-                        not recommended
-                      type: string
-                    valueFrom:
-                      description: ValueFrom refers secret. Recommended
-                      properties:
-                        secretKeyRef:
-                          description: SecretKeySelector selects a key of a Secret.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                      required:
-                      - secretKeyRef
-                      type: object
-                  required:
-                  - value
-                  type: object
-                type:
-                  description: Type for git remote server
-                  enum:
-                  - github
-                  - gitlab
-                  type: string
-              required:
-              - repository
-              - token
-              - type
-              type: object
-            jobs:
-              description: Jobs specify the tasks to be executed
-              properties:
-                postSubmit:
-                  description: PostSubmit jobs are for push events (including tag
-                    events)
-                  items:
-                    properties:
-                      after:
-                        description: After configures which jobs should be executed
-                          before this job runs
-                        items:
-                          type: string
-                        type: array
-                      args:
-                        description: 'Arguments to the entrypoint. The docker image''s
-                          CMD is used if this is not provided. Variable references
-                          $(VAR_NAME) are expanded using the container''s environment.
-                          If a variable cannot be resolved, the reference in the input
-                          string will be unchanged. The $(VAR_NAME) syntax can be
-                          escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                          will never be expanded, regardless of whether the variable
-                          exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description: 'Entrypoint array. Not executed within a shell.
-                          The docker image''s ENTRYPOINT is used if this is not provided.
-                          Variable references $(VAR_NAME) are expanded using the container''s
-                          environment. If a variable cannot be resolved, the reference
-                          in the input string will be unchanged. The $(VAR_NAME) syntax
-                          can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                          references will never be expanded, regardless of whether
-                          the variable exists or not. Cannot be updated. More info:
-                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description: List of environment variables to set in the container.
-                          Cannot be updated.
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, metadata.labels,
-                                    metadata.annotations, spec.nodeName, spec.serviceAccountName,
-                                    status.hostIP, status.podIP, status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description: List of sources to populate environment variables
-                          in the container. The keys defined within a source must
-                          be a C_IDENTIFIER. All invalid keys will be reported as
-                          an event when the container is starting. When a key exists
-                          in multiple sources, the value associated with the last
-                          source will take precedence. Values defined by an Env with
-                          a duplicate key will take precedence. Cannot be updated.
-                        items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
-                                  type: boolean
-                              type: object
-                            prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret must be
-                                    defined
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                          This field is optional to allow higher level config management
-                          to default or override container images in workload controllers
-                          like Deployments and StatefulSets.'
-                        type: string
-                      imagePullPolicy:
-                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                          Defaults to Always if :latest tag is specified, or IfNotPresent
-                          otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
-                        type: string
-                      lifecycle:
-                        description: Actions that the management system should take
-                          in response to container lifecycle events. Cannot be updated.
-                        properties:
-                          postStart:
-                            description: 'PostStart is called immediately after a
-                              container is created. If the handler fails, the container
-                              is terminated and restarted according to its restart
-                              policy. Other management of the container blocks until
-                              the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
-                            properties:
-                              exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
-                                properties:
-                                  command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory
-                                      for the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it
-                                      is not run inside a shell, so traditional shell
-                                      instructions ('|', etc) won't work. To use a
-                                      shell, you need to explicitly call out to that
-                                      shell. Exit status of 0 is treated as live/healthy
-                                      and non-zero is unhealthy.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                description: HTTPGet specifies the http request to
-                                  perform.
-                                properties:
-                                  host:
-                                    description: Host name to connect to, defaults
-                                      to the pod IP. You probably want to set "Host"
-                                      in httpHeaders instead.
-                                    type: string
-                                  httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
-                                    items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
-                                      properties:
-                                        name:
-                                          description: The header field name
-                                          type: string
-                                        value:
-                                          description: The header field value
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    description: Path to access on the HTTP server.
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook'
-                                properties:
-                                  host:
-                                    description: 'Optional: Host name to connect to,
-                                      defaults to the pod IP.'
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                          preStop:
-                            description: 'PreStop is called immediately before a container
-                              is terminated due to an API request or management event
-                              such as liveness/startup probe failure, preemption,
-                              resource contention, etc. The handler is not called
-                              if the container crashes or exits. The reason for termination
-                              is passed to the handler. The Pod''s termination grace
-                              period countdown begins before the PreStop hooked is
-                              executed. Regardless of the outcome of the handler,
-                              the container will eventually terminate within the Pod''s
-                              termination grace period. Other management of the container
-                              blocks until the hook completes or until the termination
-                              grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
-                            properties:
-                              exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
-                                properties:
-                                  command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory
-                                      for the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it
-                                      is not run inside a shell, so traditional shell
-                                      instructions ('|', etc) won't work. To use a
-                                      shell, you need to explicitly call out to that
-                                      shell. Exit status of 0 is treated as live/healthy
-                                      and non-zero is unhealthy.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                description: HTTPGet specifies the http request to
-                                  perform.
-                                properties:
-                                  host:
-                                    description: Host name to connect to, defaults
-                                      to the pod IP. You probably want to set "Host"
-                                      in httpHeaders instead.
-                                    type: string
-                                  httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
-                                    items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
-                                      properties:
-                                        name:
-                                          description: The header field name
-                                          type: string
-                                        value:
-                                          description: The header field value
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    description: Path to access on the HTTP server.
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook'
-                                properties:
-                                  host:
-                                    description: 'Optional: Host name to connect to,
-                                      defaults to the pod IP.'
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        description: 'Periodic probe of container liveness. Container
-                          will be restarted if the probe fails. Cannot be updated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description: Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                          Cannot be updated.
-                        type: string
-                      ports:
-                        description: List of ports to expose from the container. Exposing
-                          a port here gives the system additional information about
-                          the network connections a container uses, but is primarily
-                          informational. Not specifying a port here DOES NOT prevent
-                          that port from being exposed. Any port which is listening
-                          on the default "0.0.0.0" address inside a container will
-                          be accessible from the network. Cannot be updated.
-                        items:
-                          description: ContainerPort represents a network port in
-                            a single container.
-                          properties:
-                            containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x <
-                                65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port
-                                to.
-                              type: string
-                            hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x
-                                < 65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              description: Protocol for port. Must be UDP, TCP, or
-                                SCTP. Defaults to "TCP".
-                              type: string
-                          required:
-                          - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - containerPort
-                        - protocol
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                          Container will be removed from service endpoints if the
-                          probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description: 'Compute Resources required by this container.
-                          Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      securityContext:
-                        description: 'Security options the pod should run with. More
-                          info: https://kubernetes.io/docs/concepts/policy/security-context/
-                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
-                        properties:
-                          allowPrivilegeEscalation:
-                            description: 'AllowPrivilegeEscalation controls whether
-                              a process can gain more privileges than its parent process.
-                              This bool directly controls if the no_new_privs flag
-                              will be set on the container process. AllowPrivilegeEscalation
-                              is true always when the container is: 1) run as Privileged
-                              2) has CAP_SYS_ADMIN'
-                            type: boolean
-                          capabilities:
-                            description: The capabilities to add/drop when running
-                              containers. Defaults to the default set of capabilities
-                              granted by the container runtime.
-                            properties:
-                              add:
-                                description: Added capabilities
-                                items:
-                                  description: Capability represent POSIX capabilities
-                                    type
-                                  type: string
-                                type: array
-                              drop:
-                                description: Removed capabilities
-                                items:
-                                  description: Capability represent POSIX capabilities
-                                    type
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            description: Run container in privileged mode. Processes
-                              in privileged containers are essentially equivalent
-                              to root on the host. Defaults to false.
-                            type: boolean
-                          procMount:
-                            description: procMount denotes the type of proc mount
-                              to use for the containers. The default is DefaultProcMount
-                              which uses the container runtime defaults for readonly
-                              paths and masked paths. This requires the ProcMountType
-                              feature flag to be enabled.
-                            type: string
-                          readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root
-                              filesystem. Default is false.
-                            type: boolean
-                          runAsGroup:
-                            description: The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be
-                              set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            description: Indicates that the container must run as
-                              a non-root user. If true, the Kubelet will validate
-                              the image at runtime to ensure that it does not run
-                              as UID 0 (root) and fail to start the container if it
-                              does. If unset or false, no such validation will be
-                              performed. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                            type: boolean
-                          runAsUser:
-                            description: The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            description: The SELinux context to be applied to the
-                              container. If unspecified, the container runtime will
-                              allocate a random SELinux context for each container.  May
-                              also be set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
-                            properties:
-                              level:
-                                description: Level is SELinux level label that applies
-                                  to the container.
-                                type: string
-                              role:
-                                description: Role is a SELinux role label that applies
-                                  to the container.
-                                type: string
-                              type:
-                                description: Type is a SELinux type label that applies
-                                  to the container.
-                                type: string
-                              user:
-                                description: User is a SELinux user label that applies
-                                  to the container.
-                                type: string
-                            type: object
-                          windowsOptions:
-                            description: The Windows specific settings applied to
-                              all containers. If unspecified, the options from the
-                              PodSecurityContext will be used. If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
-                            properties:
-                              gmsaCredentialSpec:
-                                description: GMSACredentialSpec is where the GMSA
-                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec
-                                  named by the GMSACredentialSpecName field. This
-                                  field is alpha-level and is only honored by servers
-                                  that enable the WindowsGMSA feature flag.
-                                type: string
-                              gmsaCredentialSpecName:
-                                description: GMSACredentialSpecName is the name of
-                                  the GMSA credential spec to use. This field is alpha-level
-                                  and is only honored by servers that enable the WindowsGMSA
-                                  feature flag.
-                                type: string
-                              runAsUserName:
-                                description: The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence. This field is beta-level and may
-                                  be disabled with the WindowsRunAsUserName feature
-                                  flag.
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        description: 'StartupProbe indicates that the Pod has successfully
-                          initialized. If specified, no other probes are executed
-                          until this completes successfully. If this probe fails,
-                          the Pod will be restarted, just as if the livenessProbe
-                          failed. This can be used to provide different probe parameters
-                          at the beginning of a Pod''s lifecycle, when it might take
-                          a long time to load data or warm a cache, than during steady-state
-                          operation. This cannot be updated. This is an alpha feature
-                          enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
-                        description: Whether this container should allocate a buffer
-                          for stdin in the container runtime. If this is not set,
-                          reads from stdin in the container will always result in
-                          EOF. Default is false.
-                        type: boolean
-                      stdinOnce:
-                        description: Whether the container runtime should close the
-                          stdin channel after it has been opened by a single attach.
-                          When stdin is true the stdin stream will remain open across
-                          multiple attach sessions. If stdinOnce is set to true, stdin
-                          is opened on container start, is empty until the first client
-                          attaches to stdin, and then remains open and accepts data
-                          until the client disconnects, at which time stdin is closed
-                          and remains closed until the container is restarted. If
-                          this flag is false, a container processes that reads from
-                          stdin will never receive an EOF. Default is false
-                        type: boolean
-                      tektonTask:
-                        description: TektonTask is for referring local Tasks or the
-                          Tasks registered in tekton catalog github repo.
-                        properties:
-                          params:
-                            description: Params are input params for the task
-                            items:
-                              description: Param declares an ArrayOrString to use
-                                for the parameter called name.
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  description: ArrayOrString is a type that can hold
-                                    a single string or string array. Used in JSON
-                                    unmarshalling so that a single JSON field can
-                                    accept either an individual string or an array
-                                    of strings.
-                                  properties:
-                                    arrayVal:
-                                      items:
-                                        type: string
-                                      type: array
-                                    stringVal:
-                                      type: string
-                                    type:
-                                      description: ParamType indicates the type of
-                                        an input parameter; Used to distinguish between
-                                        a single string and an array of strings.
-                                      type: string
-                                  required:
-                                  - arrayVal
-                                  - stringVal
-                                  - type
-                                  type: object
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          resources:
-                            description: Resources are input/output resources for
-                              the task
-                            properties:
-                              inputs:
-                                description: Inputs holds the inputs resources this
-                                  task was invoked with
-                                items:
-                                  description: TaskResourceBinding points to the PipelineResource
-                                    that will be used for the Task input or output
-                                    called Name.
-                                  properties:
-                                    name:
-                                      description: Name is the name of the PipelineResource
-                                        in the Pipeline's declaration
-                                      type: string
-                                    paths:
-                                      description: 'Paths will probably be removed
-                                        in #1284, and then PipelineResourceBinding
-                                        can be used instead. The optional Path field
-                                        corresponds to a path on disk at which the
-                                        Resource can be found (used when providing
-                                        the resource via mounted volume, overriding
-                                        the default logic to fetch the Resource).'
-                                      items:
-                                        type: string
-                                      type: array
-                                    resourceRef:
-                                      description: ResourceRef is a reference to the
-                                        instance of the actual PipelineResource that
-                                        should be used
-                                      properties:
-                                        apiVersion:
-                                          description: API version of the referent
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent; More
-                                            info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                          type: string
-                                      type: object
-                                    resourceSpec:
-                                      description: ResourceSpec is specification of
-                                        a resource that should be created and consumed
-                                        by the task
-                                      properties:
-                                        description:
-                                          description: Description is a user-facing
-                                            description of the resource that may be
-                                            used to populate a UI.
-                                          type: string
-                                        params:
-                                          items:
-                                            description: ResourceParam declares a
-                                              string value to use for the parameter
-                                              called Name, and is used in the specific
-                                              context of PipelineResources.
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        secrets:
-                                          description: Secrets to fetch to populate
-                                            some of resource fields
-                                          items:
-                                            description: SecretParam indicates which
-                                              secret can be used to populate a field
-                                              of the resource
-                                            properties:
-                                              fieldName:
-                                                type: string
-                                              secretKey:
-                                                type: string
-                                              secretName:
-                                                type: string
-                                            required:
-                                            - fieldName
-                                            - secretKey
-                                            - secretName
-                                            type: object
-                                          type: array
-                                        type:
-                                          type: string
-                                      required:
-                                      - params
-                                      - type
-                                      type: object
-                                  type: object
-                                type: array
-                              outputs:
-                                description: Outputs holds the inputs resources this
-                                  task was invoked with
-                                items:
-                                  description: TaskResourceBinding points to the PipelineResource
-                                    that will be used for the Task input or output
-                                    called Name.
-                                  properties:
-                                    name:
-                                      description: Name is the name of the PipelineResource
-                                        in the Pipeline's declaration
-                                      type: string
-                                    paths:
-                                      description: 'Paths will probably be removed
-                                        in #1284, and then PipelineResourceBinding
-                                        can be used instead. The optional Path field
-                                        corresponds to a path on disk at which the
-                                        Resource can be found (used when providing
-                                        the resource via mounted volume, overriding
-                                        the default logic to fetch the Resource).'
-                                      items:
-                                        type: string
-                                      type: array
-                                    resourceRef:
-                                      description: ResourceRef is a reference to the
-                                        instance of the actual PipelineResource that
-                                        should be used
-                                      properties:
-                                        apiVersion:
-                                          description: API version of the referent
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent; More
-                                            info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                          type: string
-                                      type: object
-                                    resourceSpec:
-                                      description: ResourceSpec is specification of
-                                        a resource that should be created and consumed
-                                        by the task
-                                      properties:
-                                        description:
-                                          description: Description is a user-facing
-                                            description of the resource that may be
-                                            used to populate a UI.
-                                          type: string
-                                        params:
-                                          items:
-                                            description: ResourceParam declares a
-                                              string value to use for the parameter
-                                              called Name, and is used in the specific
-                                              context of PipelineResources.
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        secrets:
-                                          description: Secrets to fetch to populate
-                                            some of resource fields
-                                          items:
-                                            description: SecretParam indicates which
-                                              secret can be used to populate a field
-                                              of the resource
-                                            properties:
-                                              fieldName:
-                                                type: string
-                                              secretKey:
-                                                type: string
-                                              secretName:
-                                                type: string
-                                            required:
-                                            - fieldName
-                                            - secretKey
-                                            - secretName
-                                            type: object
-                                          type: array
-                                        type:
-                                          type: string
-                                      required:
-                                      - params
-                                      - type
-                                      type: object
-                                  type: object
-                                type: array
-                            type: object
-                          taskRef:
-                            description: TaskRef refers to the existing Task in local
-                              cluster or to the tekton catalog github repo.
-                            properties:
-                              catalog:
-                                description: 'Catalog is a name of the task @ tekton
-                                  catalog github repo. (e.g., s2i@0.2) FYI: https://github.com/tektoncd/catalog'
-                                type: string
-                              name:
-                                description: Name for local Tasks
-                                type: string
-                            required:
-                            - catalog
-                            - name
-                            type: object
-                          workspaces:
-                            description: Workspaces are workspaces for the task
-                            items:
-                              description: WorkspaceBinding maps a Task's declared
-                                workspace to a Volume.
-                              properties:
-                                configMap:
-                                  description: ConfigMap represents a configMap that
-                                    should populate this workspace.
-                                  properties:
-                                    defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a value
-                                        between 0 and 0777. Defaults to 0644. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
-                                      format: int32
-                                      type: integer
-                                    items:
-                                      description: If unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
-                                      items:
-                                        description: Maps a string key to a path within
-                                          a volume.
-                                        properties:
-                                          key:
-                                            description: The key to project.
-                                            type: string
-                                          mode:
-                                            description: 'Optional: mode bits to use
-                                              on this file, must be a value between
-                                              0 and 0777. If not specified, the volume
-                                              defaultMode will be used. This might
-                                              be in conflict with other options that
-                                              affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: The relative path of the
-                                              file to map the key to. May not be an
-                                              absolute path. May not contain the path
-                                              element '..'. May not start with the
-                                              string '..'.
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its keys must be defined
-                                      type: boolean
-                                  type: object
-                                emptyDir:
-                                  description: 'EmptyDir represents a temporary directory
-                                    that shares a Task''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
-                                    Either this OR PersistentVolumeClaim can be used.'
-                                  properties:
-                                    medium:
-                                      description: 'What type of storage medium should
-                                        back this directory. The default is "" which
-                                        means to use the node''s default medium. Must
-                                        be an empty string (default) or Memory. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                      type: string
-                                    sizeLimit:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: 'Total amount of local storage
-                                        required for this EmptyDir volume. The size
-                                        limit is also applicable for memory medium.
-                                        The maximum usage on memory medium EmptyDir
-                                        would be the minimum value between the SizeLimit
-                                        specified here and the sum of memory limits
-                                        of all containers in a pod. The default is
-                                        nil which means that the limit is undefined.
-                                        More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                  type: object
-                                name:
-                                  description: Name is the name of the workspace populated
-                                    by the volume.
-                                  type: string
-                                persistentVolumeClaim:
-                                  description: PersistentVolumeClaimVolumeSource represents
-                                    a reference to a PersistentVolumeClaim in the
-                                    same namespace. Either this OR EmptyDir can be
-                                    used.
-                                  properties:
-                                    claimName:
-                                      description: 'ClaimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                      type: string
-                                    readOnly:
-                                      description: Will force the ReadOnly setting
-                                        in VolumeMounts. Default false.
-                                      type: boolean
-                                  required:
-                                  - claimName
-                                  type: object
-                                secret:
-                                  description: Secret represents a secret that should
-                                    populate this workspace.
-                                  properties:
-                                    defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a value
-                                        between 0 and 0777. Defaults to 0644. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
-                                      format: int32
-                                      type: integer
-                                    items:
-                                      description: If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
-                                      items:
-                                        description: Maps a string key to a path within
-                                          a volume.
-                                        properties:
-                                          key:
-                                            description: The key to project.
-                                            type: string
-                                          mode:
-                                            description: 'Optional: mode bits to use
-                                              on this file, must be a value between
-                                              0 and 0777. If not specified, the volume
-                                              defaultMode will be used. This might
-                                              be in conflict with other options that
-                                              affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: The relative path of the
-                                              file to map the key to. May not be an
-                                              absolute path. May not contain the path
-                                              element '..'. May not start with the
-                                              string '..'.
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        keys must be defined
-                                      type: boolean
-                                    secretName:
-                                      description: 'Name of the secret in the pod''s
-                                        namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                                      type: string
-                                  type: object
-                                subPath:
-                                  description: SubPath is optionally a directory on
-                                    the volume which should be used for this binding
-                                    (i.e. the volume will be mounted at this sub directory).
-                                  type: string
-                                volumeClaimTemplate:
-                                  description: VolumeClaimTemplate is a template for
-                                    a claim that will be created in the same namespace.
-                                    The PipelineRun controller is responsible for
-                                    creating a unique claim for each instance of PipelineRun.
-                                  properties:
-                                    apiVersion:
-                                      description: 'APIVersion defines the versioned
-                                        schema of this representation of an object.
-                                        Servers should convert recognized schemas
-                                        to the latest internal value, and may reject
-                                        unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                                      type: string
-                                    kind:
-                                      description: 'Kind is a string value representing
-                                        the REST resource this object represents.
-                                        Servers may infer this from the endpoint the
-                                        client submits requests to. Cannot be updated.
-                                        In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                                      type: string
-                                    metadata:
-                                      description: 'Standard object''s metadata. More
-                                        info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                                      type: object
-                                    spec:
-                                      description: 'Spec defines the desired characteristics
-                                        of a volume requested by a pod author. More
-                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                      properties:
-                                        accessModes:
-                                          description: 'AccessModes contains the desired
-                                            access modes the volume should have. More
-                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                          items:
-                                            type: string
-                                          type: array
-                                        dataSource:
-                                          description: This field requires the VolumeSnapshotDataSource
-                                            alpha feature gate to be enabled and currently
-                                            VolumeSnapshot is the only supported data
-                                            source. If the provisioner can support
-                                            VolumeSnapshot data source, it will create
-                                            a new volume and data will be restored
-                                            to the volume at the same time. If the
-                                            provisioner does not support VolumeSnapshot
-                                            data source, volume will not be created
-                                            and the failure will be reported as an
-                                            event. In the future, we plan to support
-                                            more data source types and the behavior
-                                            of the provisioner may change.
-                                          properties:
-                                            apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
-                                              type: string
-                                            kind:
-                                              description: Kind is the type of resource
-                                                being referenced
-                                              type: string
-                                            name:
-                                              description: Name is the name of resource
-                                                being referenced
-                                              type: string
-                                          required:
-                                          - kind
-                                          - name
-                                          type: object
-                                        resources:
-                                          description: 'Resources represents the minimum
-                                            resources the volume should have. More
-                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                          properties:
-                                            limits:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              description: 'Limits describes the maximum
-                                                amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                              type: object
-                                            requests:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              description: 'Requests describes the
-                                                minimum amount of compute resources
-                                                required. If Requests is omitted for
-                                                a container, it defaults to Limits
-                                                if that is explicitly specified, otherwise
-                                                to an implementation-defined value.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                              type: object
-                                          type: object
-                                        selector:
-                                          description: A label query over volumes
-                                            to consider for binding.
-                                          properties:
-                                            matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
-                                              items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
-                                                properties:
-                                                  key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
-                                                    type: string
-                                                  operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
-                                                    type: string
-                                                  values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
-                                              type: object
-                                          type: object
-                                        storageClassName:
-                                          description: 'Name of the StorageClass required
-                                            by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                          type: string
-                                        volumeMode:
-                                          description: volumeMode defines what type
-                                            of volume is required by the claim. Value
-                                            of Filesystem is implied when not included
-                                            in claim spec. This is a beta feature.
-                                          type: string
-                                        volumeName:
-                                          description: VolumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
-                                          type: string
-                                      type: object
-                                    status:
-                                      description: 'Status represents the current
-                                        information/status of a persistent volume
-                                        claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                      properties:
-                                        accessModes:
-                                          description: 'AccessModes contains the actual
-                                            access modes the volume backing the PVC
-                                            has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                          items:
-                                            type: string
-                                          type: array
-                                        capacity:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          description: Represents the actual resources
-                                            of the underlying volume.
-                                          type: object
-                                        conditions:
-                                          description: Current Condition of persistent
-                                            volume claim. If underlying persistent
-                                            volume is being resized then the Condition
-                                            will be set to 'ResizeStarted'.
-                                          items:
-                                            description: PersistentVolumeClaimCondition
-                                              contails details about state of pvc
-                                            properties:
-                                              lastProbeTime:
-                                                description: Last time we probed the
-                                                  condition.
-                                                format: date-time
-                                                type: string
-                                              lastTransitionTime:
-                                                description: Last time the condition
-                                                  transitioned from one status to
-                                                  another.
-                                                format: date-time
-                                                type: string
-                                              message:
-                                                description: Human-readable message
-                                                  indicating details about last transition.
-                                                type: string
-                                              reason:
-                                                description: Unique, this should be
-                                                  a short, machine understandable
-                                                  string that gives the reason for
-                                                  condition's last transition. If
-                                                  it reports "ResizeStarted" that
-                                                  means the underlying persistent
-                                                  volume is being resized.
-                                                type: string
-                                              status:
-                                                type: string
-                                              type:
-                                                description: PersistentVolumeClaimConditionType
-                                                  is a valid value of PersistentVolumeClaimCondition.Type
-                                                type: string
-                                            required:
-                                            - status
-                                            - type
-                                            type: object
-                                          type: array
-                                        phase:
-                                          description: Phase represents the current
-                                            phase of PersistentVolumeClaim.
-                                          type: string
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                        required:
-                        - params
-                        - taskRef
-                        - workspaces
-                        type: object
-                      terminationMessagePath:
-                        description: 'Optional: Path at which the file to which the
-                          container''s termination message will be written is mounted
-                          into the container''s filesystem. Message written is intended
-                          to be brief final status, such as an assertion failure message.
-                          Will be truncated by the node if greater than 4096 bytes.
-                          The total message length across all containers will be limited
-                          to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
-                        type: string
-                      terminationMessagePolicy:
-                        description: Indicate how the termination message should be
-                          populated. File will use the contents of terminationMessagePath
-                          to populate the container status message on both success
-                          and failure. FallbackToLogsOnError will use the last chunk
-                          of container log output if the termination message file
-                          is empty and the container exited with an error. The log
-                          output is limited to 2048 bytes or 80 lines, whichever is
-                          smaller. Defaults to File. Cannot be updated.
-                        type: string
-                      tty:
-                        description: Whether this container should allocate a TTY
-                          for itself, also requires 'stdin' to be true. Default is
-                          false.
-                        type: boolean
-                      volumeDevices:
-                        description: volumeDevices is the list of block devices to
-                          be used by the container. This is a beta feature.
-                        items:
-                          description: volumeDevice describes a mapping of a raw block
-                            device within a container.
-                          properties:
-                            devicePath:
-                              description: devicePath is the path inside of the container
-                                that the device will be mapped to.
-                              type: string
-                            name:
-                              description: name must match the name of a persistentVolumeClaim
-                                in the pod
-                              type: string
-                          required:
-                          - devicePath
-                          - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
-                          Cannot be updated.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
-                              type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      when:
-                        description: When is condition for running the job
-                        properties:
-                          branch:
-                            items:
-                              type: string
-                            type: array
-                          ref:
-                            items:
-                              type: string
-                            type: array
-                          skipBranch:
-                            items:
-                              type: string
-                            type: array
-                          skipRef:
-                            items:
-                              type: string
-                            type: array
-                          skipTag:
-                            items:
-                              type: string
-                            type: array
-                          tag:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - branch
-                        - ref
-                        - skipBranch
-                        - skipRef
-                        - skipTag
-                        - tag
-                        type: object
-                      workingDir:
-                        description: Container's working directory. If not specified,
-                          the container runtime's default will be used, which might
-                          be configured in the container image. Cannot be updated.
-                        type: string
-                    required:
-                    - after
-                    - name
-                    type: object
-                  type: array
-                preSubmit:
-                  description: PreSubmit jobs are for pull-request events
-                  items:
-                    properties:
-                      after:
-                        description: After configures which jobs should be executed
-                          before this job runs
-                        items:
-                          type: string
-                        type: array
-                      args:
-                        description: 'Arguments to the entrypoint. The docker image''s
-                          CMD is used if this is not provided. Variable references
-                          $(VAR_NAME) are expanded using the container''s environment.
-                          If a variable cannot be resolved, the reference in the input
-                          string will be unchanged. The $(VAR_NAME) syntax can be
-                          escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                          will never be expanded, regardless of whether the variable
-                          exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description: 'Entrypoint array. Not executed within a shell.
-                          The docker image''s ENTRYPOINT is used if this is not provided.
-                          Variable references $(VAR_NAME) are expanded using the container''s
-                          environment. If a variable cannot be resolved, the reference
-                          in the input string will be unchanged. The $(VAR_NAME) syntax
-                          can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                          references will never be expanded, regardless of whether
-                          the variable exists or not. Cannot be updated. More info:
-                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description: List of environment variables to set in the container.
-                          Cannot be updated.
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, metadata.labels,
-                                    metadata.annotations, spec.nodeName, spec.serviceAccountName,
-                                    status.hostIP, status.podIP, status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description: List of sources to populate environment variables
-                          in the container. The keys defined within a source must
-                          be a C_IDENTIFIER. All invalid keys will be reported as
-                          an event when the container is starting. When a key exists
-                          in multiple sources, the value associated with the last
-                          source will take precedence. Values defined by an Env with
-                          a duplicate key will take precedence. Cannot be updated.
-                        items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
-                                  type: boolean
-                              type: object
-                            prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret must be
-                                    defined
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                          This field is optional to allow higher level config management
-                          to default or override container images in workload controllers
-                          like Deployments and StatefulSets.'
-                        type: string
-                      imagePullPolicy:
-                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                          Defaults to Always if :latest tag is specified, or IfNotPresent
-                          otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
-                        type: string
-                      lifecycle:
-                        description: Actions that the management system should take
-                          in response to container lifecycle events. Cannot be updated.
-                        properties:
-                          postStart:
-                            description: 'PostStart is called immediately after a
-                              container is created. If the handler fails, the container
-                              is terminated and restarted according to its restart
-                              policy. Other management of the container blocks until
-                              the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
-                            properties:
-                              exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
-                                properties:
-                                  command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory
-                                      for the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it
-                                      is not run inside a shell, so traditional shell
-                                      instructions ('|', etc) won't work. To use a
-                                      shell, you need to explicitly call out to that
-                                      shell. Exit status of 0 is treated as live/healthy
-                                      and non-zero is unhealthy.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                description: HTTPGet specifies the http request to
-                                  perform.
-                                properties:
-                                  host:
-                                    description: Host name to connect to, defaults
-                                      to the pod IP. You probably want to set "Host"
-                                      in httpHeaders instead.
-                                    type: string
-                                  httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
-                                    items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
-                                      properties:
-                                        name:
-                                          description: The header field name
-                                          type: string
-                                        value:
-                                          description: The header field value
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    description: Path to access on the HTTP server.
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook'
-                                properties:
-                                  host:
-                                    description: 'Optional: Host name to connect to,
-                                      defaults to the pod IP.'
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                          preStop:
-                            description: 'PreStop is called immediately before a container
-                              is terminated due to an API request or management event
-                              such as liveness/startup probe failure, preemption,
-                              resource contention, etc. The handler is not called
-                              if the container crashes or exits. The reason for termination
-                              is passed to the handler. The Pod''s termination grace
-                              period countdown begins before the PreStop hooked is
-                              executed. Regardless of the outcome of the handler,
-                              the container will eventually terminate within the Pod''s
-                              termination grace period. Other management of the container
-                              blocks until the hook completes or until the termination
-                              grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
-                            properties:
-                              exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
-                                properties:
-                                  command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory
-                                      for the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it
-                                      is not run inside a shell, so traditional shell
-                                      instructions ('|', etc) won't work. To use a
-                                      shell, you need to explicitly call out to that
-                                      shell. Exit status of 0 is treated as live/healthy
-                                      and non-zero is unhealthy.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                description: HTTPGet specifies the http request to
-                                  perform.
-                                properties:
-                                  host:
-                                    description: Host name to connect to, defaults
-                                      to the pod IP. You probably want to set "Host"
-                                      in httpHeaders instead.
-                                    type: string
-                                  httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
-                                    items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
-                                      properties:
-                                        name:
-                                          description: The header field name
-                                          type: string
-                                        value:
-                                          description: The header field value
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    description: Path to access on the HTTP server.
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook'
-                                properties:
-                                  host:
-                                    description: 'Optional: Host name to connect to,
-                                      defaults to the pod IP.'
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        description: 'Periodic probe of container liveness. Container
-                          will be restarted if the probe fails. Cannot be updated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description: Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                          Cannot be updated.
-                        type: string
-                      ports:
-                        description: List of ports to expose from the container. Exposing
-                          a port here gives the system additional information about
-                          the network connections a container uses, but is primarily
-                          informational. Not specifying a port here DOES NOT prevent
-                          that port from being exposed. Any port which is listening
-                          on the default "0.0.0.0" address inside a container will
-                          be accessible from the network. Cannot be updated.
-                        items:
-                          description: ContainerPort represents a network port in
-                            a single container.
-                          properties:
-                            containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x <
-                                65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port
-                                to.
-                              type: string
-                            hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x
-                                < 65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              description: Protocol for port. Must be UDP, TCP, or
-                                SCTP. Defaults to "TCP".
-                              type: string
-                          required:
-                          - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - containerPort
-                        - protocol
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                          Container will be removed from service endpoints if the
-                          probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description: 'Compute Resources required by this container.
-                          Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      securityContext:
-                        description: 'Security options the pod should run with. More
-                          info: https://kubernetes.io/docs/concepts/policy/security-context/
-                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
-                        properties:
-                          allowPrivilegeEscalation:
-                            description: 'AllowPrivilegeEscalation controls whether
-                              a process can gain more privileges than its parent process.
-                              This bool directly controls if the no_new_privs flag
-                              will be set on the container process. AllowPrivilegeEscalation
-                              is true always when the container is: 1) run as Privileged
-                              2) has CAP_SYS_ADMIN'
-                            type: boolean
-                          capabilities:
-                            description: The capabilities to add/drop when running
-                              containers. Defaults to the default set of capabilities
-                              granted by the container runtime.
-                            properties:
-                              add:
-                                description: Added capabilities
-                                items:
-                                  description: Capability represent POSIX capabilities
-                                    type
-                                  type: string
-                                type: array
-                              drop:
-                                description: Removed capabilities
-                                items:
-                                  description: Capability represent POSIX capabilities
-                                    type
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            description: Run container in privileged mode. Processes
-                              in privileged containers are essentially equivalent
-                              to root on the host. Defaults to false.
-                            type: boolean
-                          procMount:
-                            description: procMount denotes the type of proc mount
-                              to use for the containers. The default is DefaultProcMount
-                              which uses the container runtime defaults for readonly
-                              paths and masked paths. This requires the ProcMountType
-                              feature flag to be enabled.
-                            type: string
-                          readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root
-                              filesystem. Default is false.
-                            type: boolean
-                          runAsGroup:
-                            description: The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be
-                              set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            description: Indicates that the container must run as
-                              a non-root user. If true, the Kubelet will validate
-                              the image at runtime to ensure that it does not run
-                              as UID 0 (root) and fail to start the container if it
-                              does. If unset or false, no such validation will be
-                              performed. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                            type: boolean
-                          runAsUser:
-                            description: The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            description: The SELinux context to be applied to the
-                              container. If unspecified, the container runtime will
-                              allocate a random SELinux context for each container.  May
-                              also be set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
-                            properties:
-                              level:
-                                description: Level is SELinux level label that applies
-                                  to the container.
-                                type: string
-                              role:
-                                description: Role is a SELinux role label that applies
-                                  to the container.
-                                type: string
-                              type:
-                                description: Type is a SELinux type label that applies
-                                  to the container.
-                                type: string
-                              user:
-                                description: User is a SELinux user label that applies
-                                  to the container.
-                                type: string
-                            type: object
-                          windowsOptions:
-                            description: The Windows specific settings applied to
-                              all containers. If unspecified, the options from the
-                              PodSecurityContext will be used. If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
-                            properties:
-                              gmsaCredentialSpec:
-                                description: GMSACredentialSpec is where the GMSA
-                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec
-                                  named by the GMSACredentialSpecName field. This
-                                  field is alpha-level and is only honored by servers
-                                  that enable the WindowsGMSA feature flag.
-                                type: string
-                              gmsaCredentialSpecName:
-                                description: GMSACredentialSpecName is the name of
-                                  the GMSA credential spec to use. This field is alpha-level
-                                  and is only honored by servers that enable the WindowsGMSA
-                                  feature flag.
-                                type: string
-                              runAsUserName:
-                                description: The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence. This field is beta-level and may
-                                  be disabled with the WindowsRunAsUserName feature
-                                  flag.
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        description: 'StartupProbe indicates that the Pod has successfully
-                          initialized. If specified, no other probes are executed
-                          until this completes successfully. If this probe fails,
-                          the Pod will be restarted, just as if the livenessProbe
-                          failed. This can be used to provide different probe parameters
-                          at the beginning of a Pod''s lifecycle, when it might take
-                          a long time to load data or warm a cache, than during steady-state
-                          operation. This cannot be updated. This is an alpha feature
-                          enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
-                        description: Whether this container should allocate a buffer
-                          for stdin in the container runtime. If this is not set,
-                          reads from stdin in the container will always result in
-                          EOF. Default is false.
-                        type: boolean
-                      stdinOnce:
-                        description: Whether the container runtime should close the
-                          stdin channel after it has been opened by a single attach.
-                          When stdin is true the stdin stream will remain open across
-                          multiple attach sessions. If stdinOnce is set to true, stdin
-                          is opened on container start, is empty until the first client
-                          attaches to stdin, and then remains open and accepts data
-                          until the client disconnects, at which time stdin is closed
-                          and remains closed until the container is restarted. If
-                          this flag is false, a container processes that reads from
-                          stdin will never receive an EOF. Default is false
-                        type: boolean
-                      tektonTask:
-                        description: TektonTask is for referring local Tasks or the
-                          Tasks registered in tekton catalog github repo.
-                        properties:
-                          params:
-                            description: Params are input params for the task
-                            items:
-                              description: Param declares an ArrayOrString to use
-                                for the parameter called name.
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  description: ArrayOrString is a type that can hold
-                                    a single string or string array. Used in JSON
-                                    unmarshalling so that a single JSON field can
-                                    accept either an individual string or an array
-                                    of strings.
-                                  properties:
-                                    arrayVal:
-                                      items:
-                                        type: string
-                                      type: array
-                                    stringVal:
-                                      type: string
-                                    type:
-                                      description: ParamType indicates the type of
-                                        an input parameter; Used to distinguish between
-                                        a single string and an array of strings.
-                                      type: string
-                                  required:
-                                  - arrayVal
-                                  - stringVal
-                                  - type
-                                  type: object
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          resources:
-                            description: Resources are input/output resources for
-                              the task
-                            properties:
-                              inputs:
-                                description: Inputs holds the inputs resources this
-                                  task was invoked with
-                                items:
-                                  description: TaskResourceBinding points to the PipelineResource
-                                    that will be used for the Task input or output
-                                    called Name.
-                                  properties:
-                                    name:
-                                      description: Name is the name of the PipelineResource
-                                        in the Pipeline's declaration
-                                      type: string
-                                    paths:
-                                      description: 'Paths will probably be removed
-                                        in #1284, and then PipelineResourceBinding
-                                        can be used instead. The optional Path field
-                                        corresponds to a path on disk at which the
-                                        Resource can be found (used when providing
-                                        the resource via mounted volume, overriding
-                                        the default logic to fetch the Resource).'
-                                      items:
-                                        type: string
-                                      type: array
-                                    resourceRef:
-                                      description: ResourceRef is a reference to the
-                                        instance of the actual PipelineResource that
-                                        should be used
-                                      properties:
-                                        apiVersion:
-                                          description: API version of the referent
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent; More
-                                            info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                          type: string
-                                      type: object
-                                    resourceSpec:
-                                      description: ResourceSpec is specification of
-                                        a resource that should be created and consumed
-                                        by the task
-                                      properties:
-                                        description:
-                                          description: Description is a user-facing
-                                            description of the resource that may be
-                                            used to populate a UI.
-                                          type: string
-                                        params:
-                                          items:
-                                            description: ResourceParam declares a
-                                              string value to use for the parameter
-                                              called Name, and is used in the specific
-                                              context of PipelineResources.
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        secrets:
-                                          description: Secrets to fetch to populate
-                                            some of resource fields
-                                          items:
-                                            description: SecretParam indicates which
-                                              secret can be used to populate a field
-                                              of the resource
-                                            properties:
-                                              fieldName:
-                                                type: string
-                                              secretKey:
-                                                type: string
-                                              secretName:
-                                                type: string
-                                            required:
-                                            - fieldName
-                                            - secretKey
-                                            - secretName
-                                            type: object
-                                          type: array
-                                        type:
-                                          type: string
-                                      required:
-                                      - params
-                                      - type
-                                      type: object
-                                  type: object
-                                type: array
-                              outputs:
-                                description: Outputs holds the inputs resources this
-                                  task was invoked with
-                                items:
-                                  description: TaskResourceBinding points to the PipelineResource
-                                    that will be used for the Task input or output
-                                    called Name.
-                                  properties:
-                                    name:
-                                      description: Name is the name of the PipelineResource
-                                        in the Pipeline's declaration
-                                      type: string
-                                    paths:
-                                      description: 'Paths will probably be removed
-                                        in #1284, and then PipelineResourceBinding
-                                        can be used instead. The optional Path field
-                                        corresponds to a path on disk at which the
-                                        Resource can be found (used when providing
-                                        the resource via mounted volume, overriding
-                                        the default logic to fetch the Resource).'
-                                      items:
-                                        type: string
-                                      type: array
-                                    resourceRef:
-                                      description: ResourceRef is a reference to the
-                                        instance of the actual PipelineResource that
-                                        should be used
-                                      properties:
-                                        apiVersion:
-                                          description: API version of the referent
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent; More
-                                            info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                          type: string
-                                      type: object
-                                    resourceSpec:
-                                      description: ResourceSpec is specification of
-                                        a resource that should be created and consumed
-                                        by the task
-                                      properties:
-                                        description:
-                                          description: Description is a user-facing
-                                            description of the resource that may be
-                                            used to populate a UI.
-                                          type: string
-                                        params:
-                                          items:
-                                            description: ResourceParam declares a
-                                              string value to use for the parameter
-                                              called Name, and is used in the specific
-                                              context of PipelineResources.
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        secrets:
-                                          description: Secrets to fetch to populate
-                                            some of resource fields
-                                          items:
-                                            description: SecretParam indicates which
-                                              secret can be used to populate a field
-                                              of the resource
-                                            properties:
-                                              fieldName:
-                                                type: string
-                                              secretKey:
-                                                type: string
-                                              secretName:
-                                                type: string
-                                            required:
-                                            - fieldName
-                                            - secretKey
-                                            - secretName
-                                            type: object
-                                          type: array
-                                        type:
-                                          type: string
-                                      required:
-                                      - params
-                                      - type
-                                      type: object
-                                  type: object
-                                type: array
-                            type: object
-                          taskRef:
-                            description: TaskRef refers to the existing Task in local
-                              cluster or to the tekton catalog github repo.
-                            properties:
-                              catalog:
-                                description: 'Catalog is a name of the task @ tekton
-                                  catalog github repo. (e.g., s2i@0.2) FYI: https://github.com/tektoncd/catalog'
-                                type: string
-                              name:
-                                description: Name for local Tasks
-                                type: string
-                            required:
-                            - catalog
-                            - name
-                            type: object
-                          workspaces:
-                            description: Workspaces are workspaces for the task
-                            items:
-                              description: WorkspaceBinding maps a Task's declared
-                                workspace to a Volume.
-                              properties:
-                                configMap:
-                                  description: ConfigMap represents a configMap that
-                                    should populate this workspace.
-                                  properties:
-                                    defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a value
-                                        between 0 and 0777. Defaults to 0644. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
-                                      format: int32
-                                      type: integer
-                                    items:
-                                      description: If unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
-                                      items:
-                                        description: Maps a string key to a path within
-                                          a volume.
-                                        properties:
-                                          key:
-                                            description: The key to project.
-                                            type: string
-                                          mode:
-                                            description: 'Optional: mode bits to use
-                                              on this file, must be a value between
-                                              0 and 0777. If not specified, the volume
-                                              defaultMode will be used. This might
-                                              be in conflict with other options that
-                                              affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: The relative path of the
-                                              file to map the key to. May not be an
-                                              absolute path. May not contain the path
-                                              element '..'. May not start with the
-                                              string '..'.
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its keys must be defined
-                                      type: boolean
-                                  type: object
-                                emptyDir:
-                                  description: 'EmptyDir represents a temporary directory
-                                    that shares a Task''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
-                                    Either this OR PersistentVolumeClaim can be used.'
-                                  properties:
-                                    medium:
-                                      description: 'What type of storage medium should
-                                        back this directory. The default is "" which
-                                        means to use the node''s default medium. Must
-                                        be an empty string (default) or Memory. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                      type: string
-                                    sizeLimit:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: 'Total amount of local storage
-                                        required for this EmptyDir volume. The size
-                                        limit is also applicable for memory medium.
-                                        The maximum usage on memory medium EmptyDir
-                                        would be the minimum value between the SizeLimit
-                                        specified here and the sum of memory limits
-                                        of all containers in a pod. The default is
-                                        nil which means that the limit is undefined.
-                                        More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                  type: object
-                                name:
-                                  description: Name is the name of the workspace populated
-                                    by the volume.
-                                  type: string
-                                persistentVolumeClaim:
-                                  description: PersistentVolumeClaimVolumeSource represents
-                                    a reference to a PersistentVolumeClaim in the
-                                    same namespace. Either this OR EmptyDir can be
-                                    used.
-                                  properties:
-                                    claimName:
-                                      description: 'ClaimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                      type: string
-                                    readOnly:
-                                      description: Will force the ReadOnly setting
-                                        in VolumeMounts. Default false.
-                                      type: boolean
-                                  required:
-                                  - claimName
-                                  type: object
-                                secret:
-                                  description: Secret represents a secret that should
-                                    populate this workspace.
-                                  properties:
-                                    defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a value
-                                        between 0 and 0777. Defaults to 0644. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
-                                      format: int32
-                                      type: integer
-                                    items:
-                                      description: If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
-                                      items:
-                                        description: Maps a string key to a path within
-                                          a volume.
-                                        properties:
-                                          key:
-                                            description: The key to project.
-                                            type: string
-                                          mode:
-                                            description: 'Optional: mode bits to use
-                                              on this file, must be a value between
-                                              0 and 0777. If not specified, the volume
-                                              defaultMode will be used. This might
-                                              be in conflict with other options that
-                                              affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: The relative path of the
-                                              file to map the key to. May not be an
-                                              absolute path. May not contain the path
-                                              element '..'. May not start with the
-                                              string '..'.
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        keys must be defined
-                                      type: boolean
-                                    secretName:
-                                      description: 'Name of the secret in the pod''s
-                                        namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                                      type: string
-                                  type: object
-                                subPath:
-                                  description: SubPath is optionally a directory on
-                                    the volume which should be used for this binding
-                                    (i.e. the volume will be mounted at this sub directory).
-                                  type: string
-                                volumeClaimTemplate:
-                                  description: VolumeClaimTemplate is a template for
-                                    a claim that will be created in the same namespace.
-                                    The PipelineRun controller is responsible for
-                                    creating a unique claim for each instance of PipelineRun.
-                                  properties:
-                                    apiVersion:
-                                      description: 'APIVersion defines the versioned
-                                        schema of this representation of an object.
-                                        Servers should convert recognized schemas
-                                        to the latest internal value, and may reject
-                                        unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                                      type: string
-                                    kind:
-                                      description: 'Kind is a string value representing
-                                        the REST resource this object represents.
-                                        Servers may infer this from the endpoint the
-                                        client submits requests to. Cannot be updated.
-                                        In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                                      type: string
-                                    metadata:
-                                      description: 'Standard object''s metadata. More
-                                        info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                                      type: object
-                                    spec:
-                                      description: 'Spec defines the desired characteristics
-                                        of a volume requested by a pod author. More
-                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                      properties:
-                                        accessModes:
-                                          description: 'AccessModes contains the desired
-                                            access modes the volume should have. More
-                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                          items:
-                                            type: string
-                                          type: array
-                                        dataSource:
-                                          description: This field requires the VolumeSnapshotDataSource
-                                            alpha feature gate to be enabled and currently
-                                            VolumeSnapshot is the only supported data
-                                            source. If the provisioner can support
-                                            VolumeSnapshot data source, it will create
-                                            a new volume and data will be restored
-                                            to the volume at the same time. If the
-                                            provisioner does not support VolumeSnapshot
-                                            data source, volume will not be created
-                                            and the failure will be reported as an
-                                            event. In the future, we plan to support
-                                            more data source types and the behavior
-                                            of the provisioner may change.
-                                          properties:
-                                            apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
-                                              type: string
-                                            kind:
-                                              description: Kind is the type of resource
-                                                being referenced
-                                              type: string
-                                            name:
-                                              description: Name is the name of resource
-                                                being referenced
-                                              type: string
-                                          required:
-                                          - kind
-                                          - name
-                                          type: object
-                                        resources:
-                                          description: 'Resources represents the minimum
-                                            resources the volume should have. More
-                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                          properties:
-                                            limits:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              description: 'Limits describes the maximum
-                                                amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                              type: object
-                                            requests:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              description: 'Requests describes the
-                                                minimum amount of compute resources
-                                                required. If Requests is omitted for
-                                                a container, it defaults to Limits
-                                                if that is explicitly specified, otherwise
-                                                to an implementation-defined value.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                              type: object
-                                          type: object
-                                        selector:
-                                          description: A label query over volumes
-                                            to consider for binding.
-                                          properties:
-                                            matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
-                                              items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
-                                                properties:
-                                                  key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
-                                                    type: string
-                                                  operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
-                                                    type: string
-                                                  values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
-                                              type: object
-                                          type: object
-                                        storageClassName:
-                                          description: 'Name of the StorageClass required
-                                            by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                          type: string
-                                        volumeMode:
-                                          description: volumeMode defines what type
-                                            of volume is required by the claim. Value
-                                            of Filesystem is implied when not included
-                                            in claim spec. This is a beta feature.
-                                          type: string
-                                        volumeName:
-                                          description: VolumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
-                                          type: string
-                                      type: object
-                                    status:
-                                      description: 'Status represents the current
-                                        information/status of a persistent volume
-                                        claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                      properties:
-                                        accessModes:
-                                          description: 'AccessModes contains the actual
-                                            access modes the volume backing the PVC
-                                            has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                          items:
-                                            type: string
-                                          type: array
-                                        capacity:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          description: Represents the actual resources
-                                            of the underlying volume.
-                                          type: object
-                                        conditions:
-                                          description: Current Condition of persistent
-                                            volume claim. If underlying persistent
-                                            volume is being resized then the Condition
-                                            will be set to 'ResizeStarted'.
-                                          items:
-                                            description: PersistentVolumeClaimCondition
-                                              contails details about state of pvc
-                                            properties:
-                                              lastProbeTime:
-                                                description: Last time we probed the
-                                                  condition.
-                                                format: date-time
-                                                type: string
-                                              lastTransitionTime:
-                                                description: Last time the condition
-                                                  transitioned from one status to
-                                                  another.
-                                                format: date-time
-                                                type: string
-                                              message:
-                                                description: Human-readable message
-                                                  indicating details about last transition.
-                                                type: string
-                                              reason:
-                                                description: Unique, this should be
-                                                  a short, machine understandable
-                                                  string that gives the reason for
-                                                  condition's last transition. If
-                                                  it reports "ResizeStarted" that
-                                                  means the underlying persistent
-                                                  volume is being resized.
-                                                type: string
-                                              status:
-                                                type: string
-                                              type:
-                                                description: PersistentVolumeClaimConditionType
-                                                  is a valid value of PersistentVolumeClaimCondition.Type
-                                                type: string
-                                            required:
-                                            - status
-                                            - type
-                                            type: object
-                                          type: array
-                                        phase:
-                                          description: Phase represents the current
-                                            phase of PersistentVolumeClaim.
-                                          type: string
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                        required:
-                        - params
-                        - taskRef
-                        - workspaces
-                        type: object
-                      terminationMessagePath:
-                        description: 'Optional: Path at which the file to which the
-                          container''s termination message will be written is mounted
-                          into the container''s filesystem. Message written is intended
-                          to be brief final status, such as an assertion failure message.
-                          Will be truncated by the node if greater than 4096 bytes.
-                          The total message length across all containers will be limited
-                          to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
-                        type: string
-                      terminationMessagePolicy:
-                        description: Indicate how the termination message should be
-                          populated. File will use the contents of terminationMessagePath
-                          to populate the container status message on both success
-                          and failure. FallbackToLogsOnError will use the last chunk
-                          of container log output if the termination message file
-                          is empty and the container exited with an error. The log
-                          output is limited to 2048 bytes or 80 lines, whichever is
-                          smaller. Defaults to File. Cannot be updated.
-                        type: string
-                      tty:
-                        description: Whether this container should allocate a TTY
-                          for itself, also requires 'stdin' to be true. Default is
-                          false.
-                        type: boolean
-                      volumeDevices:
-                        description: volumeDevices is the list of block devices to
-                          be used by the container. This is a beta feature.
-                        items:
-                          description: volumeDevice describes a mapping of a raw block
-                            device within a container.
-                          properties:
-                            devicePath:
-                              description: devicePath is the path inside of the container
-                                that the device will be mapped to.
-                              type: string
-                            name:
-                              description: name must match the name of a persistentVolumeClaim
-                                in the pod
-                              type: string
-                          required:
-                          - devicePath
-                          - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
-                          Cannot be updated.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
-                              type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      when:
-                        description: When is condition for running the job
-                        properties:
-                          branch:
-                            items:
-                              type: string
-                            type: array
-                          ref:
-                            items:
-                              type: string
-                            type: array
-                          skipBranch:
-                            items:
-                              type: string
-                            type: array
-                          skipRef:
-                            items:
-                              type: string
-                            type: array
-                          skipTag:
-                            items:
-                              type: string
-                            type: array
-                          tag:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - branch
-                        - ref
-                        - skipBranch
-                        - skipRef
-                        - skipTag
-                        - tag
-                        type: object
-                      workingDir:
-                        description: Container's working directory. If not specified,
-                          the container runtime's default will be used, which might
-                          be configured in the container image. Cannot be updated.
-                        type: string
-                    required:
-                    - after
-                    - name
-                    type: object
-                  type: array
-              required:
-              - postSubmit
-              - preSubmit
-              type: object
-          required:
-          - git
-          - jobs
-          type: object
-        status:
-          description: IntegrationConfigStatus defines the observed state of IntegrationConfig
-          properties:
-            conditions:
-              description: Conditions of IntegrationConfig
-              items:
-                description: "Condition represents an observation of an object's state.
-                  Conditions are an extension mechanism intended to be used when the
-                  details of an observation are not a priori known or would not apply
-                  to all instances of a given Kind. \n Conditions should be added
-                  to explicitly convey properties that users and components care about
-                  rather than requiring those properties to be inferred from other
-                  observations. Once defined, the meaning of a Condition can not be
-                  changed arbitrarily - it becomes part of the API, and has the same
-                  backwards- and forwards-compatibility concerns of any other part
-                  of the API."
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    description: ConditionReason is intended to be a one-word, CamelCase
-                      representation of the category of cause of the current status.
-                      It is intended to be used in concise output, such as one-line
-                      kubectl get output, and in summarizing occurrences of causes.
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    description: "ConditionType is the type of the condition and is
-                      typically a CamelCased word or short phrase. \n Condition types
-                      should indicate state in the \"abnormal-true\" polarity. For
-                      example, if the condition indicates when a policy is invalid,
-                      the \"is valid\" case is probably the norm, so the condition
-                      should be called \"Invalid\"."
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          required:
-          - conditions
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: IntegrationConfig is the Schema for the integrationconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IntegrationConfigSpec defines the desired state of IntegrationConfig
+            properties:
+              git:
+                description: Git config for target repository
+                properties:
+                  apiUrl:
+                    description: ApiUrl for api server (e.g., https://api.github.com
+                      for github type), for the case where the git repository is self-hosted
+                    type: string
+                  repository:
+                    description: Repository name of git repository (in <org>/<repo>
+                      form, e.g., tmax-cloud/cicd-operator)
+                    pattern: .+/.+
+                    type: string
+                  token:
+                    description: Token
+                    properties:
+                      value:
+                        description: Value is un-encrypted plain string of git token,
+                          not recommended
+                        type: string
+                      valueFrom:
+                        description: ValueFrom refers secret. Recommended
+                        properties:
+                          secretKeyRef:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        required:
+                        - secretKeyRef
+                        type: object
+                    required:
+                    - value
+                    type: object
+                  type:
+                    description: Type for git remote server
+                    enum:
+                    - github
+                    - gitlab
+                    type: string
+                required:
+                - repository
+                - token
+                - type
+                type: object
+              jobs:
+                description: Jobs specify the tasks to be executed
+                properties:
+                  postSubmit:
+                    description: PostSubmit jobs are for push events (including tag
+                      events)
+                    items:
+                      properties:
+                        after:
+                          description: After configures which jobs should be executed
+                            before this job runs
+                          items:
+                            type: string
+                          type: array
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The docker image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, metadata.labels,
+                                      metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                      status.hostIP, status.podIP, status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The reason for
+                                termination is passed to the handler. The Pod''s termination
+                                grace period countdown begins before the PreStop hooked
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period. Other management
+                                of the container blocks until the hook completes or
+                                until the termination grace period is reached. More
+                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Exposing a port here gives the system additional information
+                            about the network connections a container uses, but is
+                            primarily informational. Not specifying a port here DOES
+                            NOT prevent that port from being exposed. Any port which
+                            is listening on the default "0.0.0.0" address inside a
+                            container will be accessible from the network. Cannot
+                            be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: Protocol for port. Must be UDP, TCP,
+                                  or SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'Security options the pod should run with.
+                            More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities
+                                      type
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities
+                                      type
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field. This
+                                    field is alpha-level and is only honored by servers
+                                    that enable the WindowsGMSA feature flag.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use. This field
+                                    is alpha-level and is only honored by servers
+                                    that enable the WindowsGMSA feature flag.
+                                  type: string
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    This field is beta-level and may be disabled with
+                                    the WindowsRunAsUserName feature flag.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. This is
+                            an alpha feature enabled by the StartupProbe feature flag.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        tektonTask:
+                          description: TektonTask is for referring local Tasks or
+                            the Tasks registered in tekton catalog github repo.
+                          properties:
+                            params:
+                              description: Params are input params for the task
+                              items:
+                                description: Param declares an ArrayOrString to use
+                                  for the parameter called name.
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    description: ArrayOrString is a type that can
+                                      hold a single string or string array. Used in
+                                      JSON unmarshalling so that a single JSON field
+                                      can accept either an individual string or an
+                                      array of strings.
+                                    properties:
+                                      arrayVal:
+                                        items:
+                                          type: string
+                                        type: array
+                                      stringVal:
+                                        type: string
+                                      type:
+                                        description: ParamType indicates the type
+                                          of an input parameter; Used to distinguish
+                                          between a single string and an array of
+                                          strings.
+                                        type: string
+                                    required:
+                                    - arrayVal
+                                    - stringVal
+                                    - type
+                                    type: object
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            resources:
+                              description: Resources are input/output resources for
+                                the task
+                              properties:
+                                inputs:
+                                  description: Inputs holds the inputs resources this
+                                    task was invoked with
+                                  items:
+                                    description: TaskResourceBinding points to the
+                                      PipelineResource that will be used for the Task
+                                      input or output called Name.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the PipelineResource
+                                          in the Pipeline's declaration
+                                        type: string
+                                      paths:
+                                        description: 'Paths will probably be removed
+                                          in #1284, and then PipelineResourceBinding
+                                          can be used instead. The optional Path field
+                                          corresponds to a path on disk at which the
+                                          Resource can be found (used when providing
+                                          the resource via mounted volume, overriding
+                                          the default logic to fetch the Resource).'
+                                        items:
+                                          type: string
+                                        type: array
+                                      resourceRef:
+                                        description: ResourceRef is a reference to
+                                          the instance of the actual PipelineResource
+                                          that should be used
+                                        properties:
+                                          apiVersion:
+                                            description: API version of the referent
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent; More
+                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                            type: string
+                                        type: object
+                                      resourceSpec:
+                                        description: ResourceSpec is specification
+                                          of a resource that should be created and
+                                          consumed by the task
+                                        properties:
+                                          description:
+                                            description: Description is a user-facing
+                                              description of the resource that may
+                                              be used to populate a UI.
+                                            type: string
+                                          params:
+                                            items:
+                                              description: ResourceParam declares
+                                                a string value to use for the parameter
+                                                called Name, and is used in the specific
+                                                context of PipelineResources.
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          secrets:
+                                            description: Secrets to fetch to populate
+                                              some of resource fields
+                                            items:
+                                              description: SecretParam indicates which
+                                                secret can be used to populate a field
+                                                of the resource
+                                              properties:
+                                                fieldName:
+                                                  type: string
+                                                secretKey:
+                                                  type: string
+                                                secretName:
+                                                  type: string
+                                              required:
+                                              - fieldName
+                                              - secretKey
+                                              - secretName
+                                              type: object
+                                            type: array
+                                          type:
+                                            type: string
+                                        required:
+                                        - params
+                                        - type
+                                        type: object
+                                    type: object
+                                  type: array
+                                outputs:
+                                  description: Outputs holds the inputs resources
+                                    this task was invoked with
+                                  items:
+                                    description: TaskResourceBinding points to the
+                                      PipelineResource that will be used for the Task
+                                      input or output called Name.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the PipelineResource
+                                          in the Pipeline's declaration
+                                        type: string
+                                      paths:
+                                        description: 'Paths will probably be removed
+                                          in #1284, and then PipelineResourceBinding
+                                          can be used instead. The optional Path field
+                                          corresponds to a path on disk at which the
+                                          Resource can be found (used when providing
+                                          the resource via mounted volume, overriding
+                                          the default logic to fetch the Resource).'
+                                        items:
+                                          type: string
+                                        type: array
+                                      resourceRef:
+                                        description: ResourceRef is a reference to
+                                          the instance of the actual PipelineResource
+                                          that should be used
+                                        properties:
+                                          apiVersion:
+                                            description: API version of the referent
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent; More
+                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                            type: string
+                                        type: object
+                                      resourceSpec:
+                                        description: ResourceSpec is specification
+                                          of a resource that should be created and
+                                          consumed by the task
+                                        properties:
+                                          description:
+                                            description: Description is a user-facing
+                                              description of the resource that may
+                                              be used to populate a UI.
+                                            type: string
+                                          params:
+                                            items:
+                                              description: ResourceParam declares
+                                                a string value to use for the parameter
+                                                called Name, and is used in the specific
+                                                context of PipelineResources.
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          secrets:
+                                            description: Secrets to fetch to populate
+                                              some of resource fields
+                                            items:
+                                              description: SecretParam indicates which
+                                                secret can be used to populate a field
+                                                of the resource
+                                              properties:
+                                                fieldName:
+                                                  type: string
+                                                secretKey:
+                                                  type: string
+                                                secretName:
+                                                  type: string
+                                              required:
+                                              - fieldName
+                                              - secretKey
+                                              - secretName
+                                              type: object
+                                            type: array
+                                          type:
+                                            type: string
+                                        required:
+                                        - params
+                                        - type
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            taskRef:
+                              description: TaskRef refers to the existing Task in
+                                local cluster or to the tekton catalog github repo.
+                              properties:
+                                catalog:
+                                  description: 'Catalog is a name of the task @ tekton
+                                    catalog github repo. (e.g., s2i@0.2) FYI: https://github.com/tektoncd/catalog'
+                                  type: string
+                                name:
+                                  description: Name for local Tasks
+                                  type: string
+                              required:
+                              - catalog
+                              - name
+                              type: object
+                            workspaces:
+                              description: Workspaces are workspaces for the task
+                              items:
+                                description: WorkspaceBinding maps a Task's declared
+                                  workspace to a Volume.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap represents a configMap
+                                      that should populate this workspace.
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits to use on
+                                          created files by default. Must be a value
+                                          between 0 and 0777. Defaults to 0644. Directories
+                                          within the path are not affected by this
+                                          setting. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits to
+                                                use on this file, must be a value
+                                                between 0 and 0777. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  emptyDir:
+                                    description: 'EmptyDir represents a temporary
+                                      directory that shares a Task''s lifetime. More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                      Either this OR PersistentVolumeClaim can be
+                                      used.'
+                                    properties:
+                                      medium:
+                                        description: 'What type of storage medium
+                                          should back this directory. The default
+                                          is "" which means to use the node''s default
+                                          medium. Must be an empty string (default)
+                                          or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        type: string
+                                      sizeLimit:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: 'Total amount of local storage
+                                          required for this EmptyDir volume. The size
+                                          limit is also applicable for memory medium.
+                                          The maximum usage on memory medium EmptyDir
+                                          would be the minimum value between the SizeLimit
+                                          specified here and the sum of memory limits
+                                          of all containers in a pod. The default
+                                          is nil which means that the limit is undefined.
+                                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  name:
+                                    description: Name is the name of the workspace
+                                      populated by the volume.
+                                    type: string
+                                  persistentVolumeClaim:
+                                    description: PersistentVolumeClaimVolumeSource
+                                      represents a reference to a PersistentVolumeClaim
+                                      in the same namespace. Either this OR EmptyDir
+                                      can be used.
+                                    properties:
+                                      claimName:
+                                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                                          in the same namespace as the pod using this
+                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        type: string
+                                      readOnly:
+                                        description: Will force the ReadOnly setting
+                                          in VolumeMounts. Default false.
+                                        type: boolean
+                                    required:
+                                    - claimName
+                                    type: object
+                                  secret:
+                                    description: Secret represents a secret that should
+                                      populate this workspace.
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits to use on
+                                          created files by default. Must be a value
+                                          between 0 and 0777. Defaults to 0644. Directories
+                                          within the path are not affected by this
+                                          setting. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits to
+                                                use on this file, must be a value
+                                                between 0 and 0777. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its keys must be defined
+                                        type: boolean
+                                      secretName:
+                                        description: 'Name of the secret in the pod''s
+                                          namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        type: string
+                                    type: object
+                                  subPath:
+                                    description: SubPath is optionally a directory
+                                      on the volume which should be used for this
+                                      binding (i.e. the volume will be mounted at
+                                      this sub directory).
+                                    type: string
+                                  volumeClaimTemplate:
+                                    description: VolumeClaimTemplate is a template
+                                      for a claim that will be created in the same
+                                      namespace. The PipelineRun controller is responsible
+                                      for creating a unique claim for each instance
+                                      of PipelineRun.
+                                    properties:
+                                      apiVersion:
+                                        description: 'APIVersion defines the versioned
+                                          schema of this representation of an object.
+                                          Servers should convert recognized schemas
+                                          to the latest internal value, and may reject
+                                          unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                        type: string
+                                      kind:
+                                        description: 'Kind is a string value representing
+                                          the REST resource this object represents.
+                                          Servers may infer this from the endpoint
+                                          the client submits requests to. Cannot be
+                                          updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                        type: string
+                                      metadata:
+                                        description: 'Standard object''s metadata.
+                                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                        type: object
+                                      spec:
+                                        description: 'Spec defines the desired characteristics
+                                          of a volume requested by a pod author. More
+                                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        properties:
+                                          accessModes:
+                                            description: 'AccessModes contains the
+                                              desired access modes the volume should
+                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                            items:
+                                              type: string
+                                            type: array
+                                          dataSource:
+                                            description: This field requires the VolumeSnapshotDataSource
+                                              alpha feature gate to be enabled and
+                                              currently VolumeSnapshot is the only
+                                              supported data source. If the provisioner
+                                              can support VolumeSnapshot data source,
+                                              it will create a new volume and data
+                                              will be restored to the volume at the
+                                              same time. If the provisioner does not
+                                              support VolumeSnapshot data source,
+                                              volume will not be created and the failure
+                                              will be reported as an event. In the
+                                              future, we plan to support more data
+                                              source types and the behavior of the
+                                              provisioner may change.
+                                            properties:
+                                              apiGroup:
+                                                description: APIGroup is the group
+                                                  for the resource being referenced.
+                                                  If APIGroup is not specified, the
+                                                  specified Kind must be in the core
+                                                  API group. For any other third-party
+                                                  types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                          resources:
+                                            description: 'Resources represents the
+                                              minimum resources the volume should
+                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Limits describes the
+                                                  maximum amount of compute resources
+                                                  allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Requests describes the
+                                                  minimum amount of compute resources
+                                                  required. If Requests is omitted
+                                                  for a container, it defaults to
+                                                  Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined
+                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                type: object
+                                            type: object
+                                          selector:
+                                            description: A label query over volumes
+                                              to consider for binding.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          storageClassName:
+                                            description: 'Name of the StorageClass
+                                              required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            type: string
+                                          volumeMode:
+                                            description: volumeMode defines what type
+                                              of volume is required by the claim.
+                                              Value of Filesystem is implied when
+                                              not included in claim spec. This is
+                                              a beta feature.
+                                            type: string
+                                          volumeName:
+                                            description: VolumeName is the binding
+                                              reference to the PersistentVolume backing
+                                              this claim.
+                                            type: string
+                                        type: object
+                                      status:
+                                        description: 'Status represents the current
+                                          information/status of a persistent volume
+                                          claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        properties:
+                                          accessModes:
+                                            description: 'AccessModes contains the
+                                              actual access modes the volume backing
+                                              the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                            items:
+                                              type: string
+                                            type: array
+                                          capacity:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: Represents the actual resources
+                                              of the underlying volume.
+                                            type: object
+                                          conditions:
+                                            description: Current Condition of persistent
+                                              volume claim. If underlying persistent
+                                              volume is being resized then the Condition
+                                              will be set to 'ResizeStarted'.
+                                            items:
+                                              description: PersistentVolumeClaimCondition
+                                                contails details about state of pvc
+                                              properties:
+                                                lastProbeTime:
+                                                  description: Last time we probed
+                                                    the condition.
+                                                  format: date-time
+                                                  type: string
+                                                lastTransitionTime:
+                                                  description: Last time the condition
+                                                    transitioned from one status to
+                                                    another.
+                                                  format: date-time
+                                                  type: string
+                                                message:
+                                                  description: Human-readable message
+                                                    indicating details about last
+                                                    transition.
+                                                  type: string
+                                                reason:
+                                                  description: Unique, this should
+                                                    be a short, machine understandable
+                                                    string that gives the reason for
+                                                    condition's last transition. If
+                                                    it reports "ResizeStarted" that
+                                                    means the underlying persistent
+                                                    volume is being resized.
+                                                  type: string
+                                                status:
+                                                  type: string
+                                                type:
+                                                  description: PersistentVolumeClaimConditionType
+                                                    is a valid value of PersistentVolumeClaimCondition.Type
+                                                  type: string
+                                              required:
+                                              - status
+                                              - type
+                                              type: object
+                                            type: array
+                                          phase:
+                                            description: Phase represents the current
+                                              phase of PersistentVolumeClaim.
+                                            type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                          required:
+                          - params
+                          - taskRef
+                          - workspaces
+                          type: object
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should
+                            be populated. File will use the contents of terminationMessagePath
+                            to populate the container status message on both success
+                            and failure. FallbackToLogsOnError will use the last chunk
+                            of container log output if the termination message file
+                            is empty and the container exited with an error. The log
+                            output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container. This is a beta feature.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        when:
+                          description: When is condition for running the job
+                          properties:
+                            branch:
+                              items:
+                                type: string
+                              type: array
+                            ref:
+                              items:
+                                type: string
+                              type: array
+                            skipBranch:
+                              items:
+                                type: string
+                              type: array
+                            skipRef:
+                              items:
+                                type: string
+                              type: array
+                            skipTag:
+                              items:
+                                type: string
+                              type: array
+                            tag:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - branch
+                          - ref
+                          - skipBranch
+                          - skipRef
+                          - skipTag
+                          - tag
+                          type: object
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - after
+                      - name
+                      type: object
+                    type: array
+                  preSubmit:
+                    description: PreSubmit jobs are for pull-request events
+                    items:
+                      properties:
+                        after:
+                          description: After configures which jobs should be executed
+                            before this job runs
+                          items:
+                            type: string
+                          type: array
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The docker image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, metadata.labels,
+                                      metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                      status.hostIP, status.podIP, status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The reason for
+                                termination is passed to the handler. The Pod''s termination
+                                grace period countdown begins before the PreStop hooked
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period. Other management
+                                of the container blocks until the hook completes or
+                                until the termination grace period is reached. More
+                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Exposing a port here gives the system additional information
+                            about the network connections a container uses, but is
+                            primarily informational. Not specifying a port here DOES
+                            NOT prevent that port from being exposed. Any port which
+                            is listening on the default "0.0.0.0" address inside a
+                            container will be accessible from the network. Cannot
+                            be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: Protocol for port. Must be UDP, TCP,
+                                  or SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'Security options the pod should run with.
+                            More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities
+                                      type
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities
+                                      type
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field. This
+                                    field is alpha-level and is only honored by servers
+                                    that enable the WindowsGMSA feature flag.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use. This field
+                                    is alpha-level and is only honored by servers
+                                    that enable the WindowsGMSA feature flag.
+                                  type: string
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    This field is beta-level and may be disabled with
+                                    the WindowsRunAsUserName feature flag.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. This is
+                            an alpha feature enabled by the StartupProbe feature flag.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        tektonTask:
+                          description: TektonTask is for referring local Tasks or
+                            the Tasks registered in tekton catalog github repo.
+                          properties:
+                            params:
+                              description: Params are input params for the task
+                              items:
+                                description: Param declares an ArrayOrString to use
+                                  for the parameter called name.
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    description: ArrayOrString is a type that can
+                                      hold a single string or string array. Used in
+                                      JSON unmarshalling so that a single JSON field
+                                      can accept either an individual string or an
+                                      array of strings.
+                                    properties:
+                                      arrayVal:
+                                        items:
+                                          type: string
+                                        type: array
+                                      stringVal:
+                                        type: string
+                                      type:
+                                        description: ParamType indicates the type
+                                          of an input parameter; Used to distinguish
+                                          between a single string and an array of
+                                          strings.
+                                        type: string
+                                    required:
+                                    - arrayVal
+                                    - stringVal
+                                    - type
+                                    type: object
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            resources:
+                              description: Resources are input/output resources for
+                                the task
+                              properties:
+                                inputs:
+                                  description: Inputs holds the inputs resources this
+                                    task was invoked with
+                                  items:
+                                    description: TaskResourceBinding points to the
+                                      PipelineResource that will be used for the Task
+                                      input or output called Name.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the PipelineResource
+                                          in the Pipeline's declaration
+                                        type: string
+                                      paths:
+                                        description: 'Paths will probably be removed
+                                          in #1284, and then PipelineResourceBinding
+                                          can be used instead. The optional Path field
+                                          corresponds to a path on disk at which the
+                                          Resource can be found (used when providing
+                                          the resource via mounted volume, overriding
+                                          the default logic to fetch the Resource).'
+                                        items:
+                                          type: string
+                                        type: array
+                                      resourceRef:
+                                        description: ResourceRef is a reference to
+                                          the instance of the actual PipelineResource
+                                          that should be used
+                                        properties:
+                                          apiVersion:
+                                            description: API version of the referent
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent; More
+                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                            type: string
+                                        type: object
+                                      resourceSpec:
+                                        description: ResourceSpec is specification
+                                          of a resource that should be created and
+                                          consumed by the task
+                                        properties:
+                                          description:
+                                            description: Description is a user-facing
+                                              description of the resource that may
+                                              be used to populate a UI.
+                                            type: string
+                                          params:
+                                            items:
+                                              description: ResourceParam declares
+                                                a string value to use for the parameter
+                                                called Name, and is used in the specific
+                                                context of PipelineResources.
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          secrets:
+                                            description: Secrets to fetch to populate
+                                              some of resource fields
+                                            items:
+                                              description: SecretParam indicates which
+                                                secret can be used to populate a field
+                                                of the resource
+                                              properties:
+                                                fieldName:
+                                                  type: string
+                                                secretKey:
+                                                  type: string
+                                                secretName:
+                                                  type: string
+                                              required:
+                                              - fieldName
+                                              - secretKey
+                                              - secretName
+                                              type: object
+                                            type: array
+                                          type:
+                                            type: string
+                                        required:
+                                        - params
+                                        - type
+                                        type: object
+                                    type: object
+                                  type: array
+                                outputs:
+                                  description: Outputs holds the inputs resources
+                                    this task was invoked with
+                                  items:
+                                    description: TaskResourceBinding points to the
+                                      PipelineResource that will be used for the Task
+                                      input or output called Name.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the PipelineResource
+                                          in the Pipeline's declaration
+                                        type: string
+                                      paths:
+                                        description: 'Paths will probably be removed
+                                          in #1284, and then PipelineResourceBinding
+                                          can be used instead. The optional Path field
+                                          corresponds to a path on disk at which the
+                                          Resource can be found (used when providing
+                                          the resource via mounted volume, overriding
+                                          the default logic to fetch the Resource).'
+                                        items:
+                                          type: string
+                                        type: array
+                                      resourceRef:
+                                        description: ResourceRef is a reference to
+                                          the instance of the actual PipelineResource
+                                          that should be used
+                                        properties:
+                                          apiVersion:
+                                            description: API version of the referent
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent; More
+                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                            type: string
+                                        type: object
+                                      resourceSpec:
+                                        description: ResourceSpec is specification
+                                          of a resource that should be created and
+                                          consumed by the task
+                                        properties:
+                                          description:
+                                            description: Description is a user-facing
+                                              description of the resource that may
+                                              be used to populate a UI.
+                                            type: string
+                                          params:
+                                            items:
+                                              description: ResourceParam declares
+                                                a string value to use for the parameter
+                                                called Name, and is used in the specific
+                                                context of PipelineResources.
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          secrets:
+                                            description: Secrets to fetch to populate
+                                              some of resource fields
+                                            items:
+                                              description: SecretParam indicates which
+                                                secret can be used to populate a field
+                                                of the resource
+                                              properties:
+                                                fieldName:
+                                                  type: string
+                                                secretKey:
+                                                  type: string
+                                                secretName:
+                                                  type: string
+                                              required:
+                                              - fieldName
+                                              - secretKey
+                                              - secretName
+                                              type: object
+                                            type: array
+                                          type:
+                                            type: string
+                                        required:
+                                        - params
+                                        - type
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            taskRef:
+                              description: TaskRef refers to the existing Task in
+                                local cluster or to the tekton catalog github repo.
+                              properties:
+                                catalog:
+                                  description: 'Catalog is a name of the task @ tekton
+                                    catalog github repo. (e.g., s2i@0.2) FYI: https://github.com/tektoncd/catalog'
+                                  type: string
+                                name:
+                                  description: Name for local Tasks
+                                  type: string
+                              required:
+                              - catalog
+                              - name
+                              type: object
+                            workspaces:
+                              description: Workspaces are workspaces for the task
+                              items:
+                                description: WorkspaceBinding maps a Task's declared
+                                  workspace to a Volume.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap represents a configMap
+                                      that should populate this workspace.
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits to use on
+                                          created files by default. Must be a value
+                                          between 0 and 0777. Defaults to 0644. Directories
+                                          within the path are not affected by this
+                                          setting. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits to
+                                                use on this file, must be a value
+                                                between 0 and 0777. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  emptyDir:
+                                    description: 'EmptyDir represents a temporary
+                                      directory that shares a Task''s lifetime. More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                      Either this OR PersistentVolumeClaim can be
+                                      used.'
+                                    properties:
+                                      medium:
+                                        description: 'What type of storage medium
+                                          should back this directory. The default
+                                          is "" which means to use the node''s default
+                                          medium. Must be an empty string (default)
+                                          or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        type: string
+                                      sizeLimit:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: 'Total amount of local storage
+                                          required for this EmptyDir volume. The size
+                                          limit is also applicable for memory medium.
+                                          The maximum usage on memory medium EmptyDir
+                                          would be the minimum value between the SizeLimit
+                                          specified here and the sum of memory limits
+                                          of all containers in a pod. The default
+                                          is nil which means that the limit is undefined.
+                                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  name:
+                                    description: Name is the name of the workspace
+                                      populated by the volume.
+                                    type: string
+                                  persistentVolumeClaim:
+                                    description: PersistentVolumeClaimVolumeSource
+                                      represents a reference to a PersistentVolumeClaim
+                                      in the same namespace. Either this OR EmptyDir
+                                      can be used.
+                                    properties:
+                                      claimName:
+                                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                                          in the same namespace as the pod using this
+                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        type: string
+                                      readOnly:
+                                        description: Will force the ReadOnly setting
+                                          in VolumeMounts. Default false.
+                                        type: boolean
+                                    required:
+                                    - claimName
+                                    type: object
+                                  secret:
+                                    description: Secret represents a secret that should
+                                      populate this workspace.
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits to use on
+                                          created files by default. Must be a value
+                                          between 0 and 0777. Defaults to 0644. Directories
+                                          within the path are not affected by this
+                                          setting. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits to
+                                                use on this file, must be a value
+                                                between 0 and 0777. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its keys must be defined
+                                        type: boolean
+                                      secretName:
+                                        description: 'Name of the secret in the pod''s
+                                          namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        type: string
+                                    type: object
+                                  subPath:
+                                    description: SubPath is optionally a directory
+                                      on the volume which should be used for this
+                                      binding (i.e. the volume will be mounted at
+                                      this sub directory).
+                                    type: string
+                                  volumeClaimTemplate:
+                                    description: VolumeClaimTemplate is a template
+                                      for a claim that will be created in the same
+                                      namespace. The PipelineRun controller is responsible
+                                      for creating a unique claim for each instance
+                                      of PipelineRun.
+                                    properties:
+                                      apiVersion:
+                                        description: 'APIVersion defines the versioned
+                                          schema of this representation of an object.
+                                          Servers should convert recognized schemas
+                                          to the latest internal value, and may reject
+                                          unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                        type: string
+                                      kind:
+                                        description: 'Kind is a string value representing
+                                          the REST resource this object represents.
+                                          Servers may infer this from the endpoint
+                                          the client submits requests to. Cannot be
+                                          updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                        type: string
+                                      metadata:
+                                        description: 'Standard object''s metadata.
+                                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                        type: object
+                                      spec:
+                                        description: 'Spec defines the desired characteristics
+                                          of a volume requested by a pod author. More
+                                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        properties:
+                                          accessModes:
+                                            description: 'AccessModes contains the
+                                              desired access modes the volume should
+                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                            items:
+                                              type: string
+                                            type: array
+                                          dataSource:
+                                            description: This field requires the VolumeSnapshotDataSource
+                                              alpha feature gate to be enabled and
+                                              currently VolumeSnapshot is the only
+                                              supported data source. If the provisioner
+                                              can support VolumeSnapshot data source,
+                                              it will create a new volume and data
+                                              will be restored to the volume at the
+                                              same time. If the provisioner does not
+                                              support VolumeSnapshot data source,
+                                              volume will not be created and the failure
+                                              will be reported as an event. In the
+                                              future, we plan to support more data
+                                              source types and the behavior of the
+                                              provisioner may change.
+                                            properties:
+                                              apiGroup:
+                                                description: APIGroup is the group
+                                                  for the resource being referenced.
+                                                  If APIGroup is not specified, the
+                                                  specified Kind must be in the core
+                                                  API group. For any other third-party
+                                                  types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                          resources:
+                                            description: 'Resources represents the
+                                              minimum resources the volume should
+                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Limits describes the
+                                                  maximum amount of compute resources
+                                                  allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Requests describes the
+                                                  minimum amount of compute resources
+                                                  required. If Requests is omitted
+                                                  for a container, it defaults to
+                                                  Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined
+                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                type: object
+                                            type: object
+                                          selector:
+                                            description: A label query over volumes
+                                              to consider for binding.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          storageClassName:
+                                            description: 'Name of the StorageClass
+                                              required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            type: string
+                                          volumeMode:
+                                            description: volumeMode defines what type
+                                              of volume is required by the claim.
+                                              Value of Filesystem is implied when
+                                              not included in claim spec. This is
+                                              a beta feature.
+                                            type: string
+                                          volumeName:
+                                            description: VolumeName is the binding
+                                              reference to the PersistentVolume backing
+                                              this claim.
+                                            type: string
+                                        type: object
+                                      status:
+                                        description: 'Status represents the current
+                                          information/status of a persistent volume
+                                          claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        properties:
+                                          accessModes:
+                                            description: 'AccessModes contains the
+                                              actual access modes the volume backing
+                                              the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                            items:
+                                              type: string
+                                            type: array
+                                          capacity:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: Represents the actual resources
+                                              of the underlying volume.
+                                            type: object
+                                          conditions:
+                                            description: Current Condition of persistent
+                                              volume claim. If underlying persistent
+                                              volume is being resized then the Condition
+                                              will be set to 'ResizeStarted'.
+                                            items:
+                                              description: PersistentVolumeClaimCondition
+                                                contails details about state of pvc
+                                              properties:
+                                                lastProbeTime:
+                                                  description: Last time we probed
+                                                    the condition.
+                                                  format: date-time
+                                                  type: string
+                                                lastTransitionTime:
+                                                  description: Last time the condition
+                                                    transitioned from one status to
+                                                    another.
+                                                  format: date-time
+                                                  type: string
+                                                message:
+                                                  description: Human-readable message
+                                                    indicating details about last
+                                                    transition.
+                                                  type: string
+                                                reason:
+                                                  description: Unique, this should
+                                                    be a short, machine understandable
+                                                    string that gives the reason for
+                                                    condition's last transition. If
+                                                    it reports "ResizeStarted" that
+                                                    means the underlying persistent
+                                                    volume is being resized.
+                                                  type: string
+                                                status:
+                                                  type: string
+                                                type:
+                                                  description: PersistentVolumeClaimConditionType
+                                                    is a valid value of PersistentVolumeClaimCondition.Type
+                                                  type: string
+                                              required:
+                                              - status
+                                              - type
+                                              type: object
+                                            type: array
+                                          phase:
+                                            description: Phase represents the current
+                                              phase of PersistentVolumeClaim.
+                                            type: string
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                          required:
+                          - params
+                          - taskRef
+                          - workspaces
+                          type: object
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should
+                            be populated. File will use the contents of terminationMessagePath
+                            to populate the container status message on both success
+                            and failure. FallbackToLogsOnError will use the last chunk
+                            of container log output if the termination message file
+                            is empty and the container exited with an error. The log
+                            output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container. This is a beta feature.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        when:
+                          description: When is condition for running the job
+                          properties:
+                            branch:
+                              items:
+                                type: string
+                              type: array
+                            ref:
+                              items:
+                                type: string
+                              type: array
+                            skipBranch:
+                              items:
+                                type: string
+                              type: array
+                            skipRef:
+                              items:
+                                type: string
+                              type: array
+                            skipTag:
+                              items:
+                                type: string
+                              type: array
+                            tag:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - branch
+                          - ref
+                          - skipBranch
+                          - skipRef
+                          - skipTag
+                          - tag
+                          type: object
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - after
+                      - name
+                      type: object
+                    type: array
+                required:
+                - postSubmit
+                - preSubmit
+                type: object
+            required:
+            - git
+            - jobs
+            type: object
+          status:
+            description: IntegrationConfigStatus defines the observed state of IntegrationConfig
+            properties:
+              conditions:
+                description: Conditions of IntegrationConfig
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/cicd.tmax.io_integrationjobs.yaml
+++ b/config/crd/bases/cicd.tmax.io_integrationjobs.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: integrationjobs.cicd.tmax.io
 spec:
@@ -15,1873 +15,1899 @@ spec:
     plural: integrationjobs
     singular: integrationjob
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: IntegrationJob is the Schema for the integrationjobs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IntegrationJobSpec defines the desired state of IntegrationJob
-          properties:
-            configRef:
-              description: ConfigRef refers to the corresponding IntegrationConfig
-              properties:
-                name:
-                  type: string
-                type:
-                  type: string
-              required:
-              - name
-              - type
-              type: object
-            id:
-              description: Id is a unique random string for the IntegrationJob
-              type: string
-            jobs:
-              description: Jobs are the tasks to be executed
-              items:
-                properties:
-                  after:
-                    description: After configures which jobs should be executed before
-                      this job runs
-                    items:
-                      type: string
-                    type: array
-                  args:
-                    description: 'Arguments to the entrypoint. The docker image''s
-                      CMD is used if this is not provided. Variable references $(VAR_NAME)
-                      are expanded using the container''s environment. If a variable
-                      cannot be resolved, the reference in the input string will be
-                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
-                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
-                      regardless of whether the variable exists or not. Cannot be
-                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                    items:
-                      type: string
-                    type: array
-                  command:
-                    description: 'Entrypoint array. Not executed within a shell. The
-                      docker image''s ENTRYPOINT is used if this is not provided.
-                      Variable references $(VAR_NAME) are expanded using the container''s
-                      environment. If a variable cannot be resolved, the reference
-                      in the input string will be unchanged. The $(VAR_NAME) syntax
-                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                      will never be expanded, regardless of whether the variable exists
-                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                    items:
-                      type: string
-                    type: array
-                  env:
-                    description: List of environment variables to set in the container.
-                      Cannot be updated.
-                    items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
-                      properties:
-                        name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
-                          type: string
-                        value:
-                          description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
-                          type: string
-                        valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
-                          properties:
-                            configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
-                              properties:
-                                key:
-                                  description: The key to select.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                            fieldRef:
-                              description: 'Selects a field of the pod: supports metadata.name,
-                                metadata.namespace, metadata.labels, metadata.annotations,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP,
-                                status.podIP, status.podIPs.'
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            resourceFieldRef:
-                              description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                            secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  envFrom:
-                    description: List of sources to populate environment variables
-                      in the container. The keys defined within a source must be a
-                      C_IDENTIFIER. All invalid keys will be reported as an event
-                      when the container is starting. When a key exists in multiple
-                      sources, the value associated with the last source will take
-                      precedence. Values defined by an Env with a duplicate key will
-                      take precedence. Cannot be updated.
-                    items:
-                      description: EnvFromSource represents the source of a set of
-                        ConfigMaps
-                      properties:
-                        configMapRef:
-                          description: The ConfigMap to select from
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap must be defined
-                              type: boolean
-                          type: object
-                        prefix:
-                          description: An optional identifier to prepend to each key
-                            in the ConfigMap. Must be a C_IDENTIFIER.
-                          type: string
-                        secretRef:
-                          description: The Secret to select from
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret must be defined
-                              type: boolean
-                          type: object
-                      type: object
-                    type: array
-                  image:
-                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                      This field is optional to allow higher level config management
-                      to default or override container images in workload controllers
-                      like Deployments and StatefulSets.'
-                    type: string
-                  imagePullPolicy:
-                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                      Defaults to Always if :latest tag is specified, or IfNotPresent
-                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
-                    type: string
-                  lifecycle:
-                    description: Actions that the management system should take in
-                      response to container lifecycle events. Cannot be updated.
-                    properties:
-                      postStart:
-                        description: 'PostStart is called immediately after a container
-                          is created. If the handler fails, the container is terminated
-                          and restarted according to its restart policy. Other management
-                          of the container blocks until the hook completes. More info:
-                          https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                        type: object
-                      preStop:
-                        description: 'PreStop is called immediately before a container
-                          is terminated due to an API request or management event
-                          such as liveness/startup probe failure, preemption, resource
-                          contention, etc. The handler is not called if the container
-                          crashes or exits. The reason for termination is passed to
-                          the handler. The Pod''s termination grace period countdown
-                          begins before the PreStop hooked is executed. Regardless
-                          of the outcome of the handler, the container will eventually
-                          terminate within the Pod''s termination grace period. Other
-                          management of the container blocks until the hook completes
-                          or until the termination grace period is reached. More info:
-                          https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                        type: object
-                    type: object
-                  livenessProbe:
-                    description: 'Periodic probe of container liveness. Container
-                      will be restarted if the probe fails. Cannot be updated. More
-                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                    properties:
-                      exec:
-                        description: One and only one of the following should be specified.
-                          Exec specifies the action to take.
-                        properties:
-                          command:
-                            description: Command is the command line to execute inside
-                              the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      failureThreshold:
-                        description: Minimum consecutive failures for the probe to
-                          be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGet specifies the http request to perform.
-                        properties:
-                          host:
-                            description: Host name to connect to, defaults to the
-                              pod IP. You probably want to set "Host" in httpHeaders
-                              instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: The header field name
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Name or number of the port to access on the
-                              container. Number must be in the range 1 to 65535. Name
-                              must be an IANA_SVC_NAME.
-                            x-kubernetes-int-or-string: true
-                          scheme:
-                            description: Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: Minimum consecutive successes for the probe to
-                          be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: 'TCPSocket specifies an action involving a TCP
-                          port. TCP hooks not yet supported TODO: implement a realistic
-                          TCP lifecycle hook'
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Number or name of the port to access on the
-                              container. Number must be in the range 1 to 65535. Name
-                              must be an IANA_SVC_NAME.
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                    type: object
-                  name:
-                    description: Name of the container specified as a DNS_LABEL. Each
-                      container in a pod must have a unique name (DNS_LABEL). Cannot
-                      be updated.
-                    type: string
-                  ports:
-                    description: List of ports to expose from the container. Exposing
-                      a port here gives the system additional information about the
-                      network connections a container uses, but is primarily informational.
-                      Not specifying a port here DOES NOT prevent that port from being
-                      exposed. Any port which is listening on the default "0.0.0.0"
-                      address inside a container will be accessible from the network.
-                      Cannot be updated.
-                    items:
-                      description: ContainerPort represents a network port in a single
-                        container.
-                      properties:
-                        containerPort:
-                          description: Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
-                          format: int32
-                          type: integer
-                        hostIP:
-                          description: What host IP to bind the external port to.
-                          type: string
-                        hostPort:
-                          description: Number of port to expose on the host. If specified,
-                            this must be a valid port number, 0 < x < 65536. If HostNetwork
-                            is specified, this must match ContainerPort. Most containers
-                            do not need this.
-                          format: int32
-                          type: integer
-                        name:
-                          description: If specified, this must be an IANA_SVC_NAME
-                            and unique within the pod. Each named port in a pod must
-                            have a unique name. Name for the port that can be referred
-                            to by services.
-                          type: string
-                        protocol:
-                          description: Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
-                          type: string
-                      required:
-                      - containerPort
-                      type: object
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - containerPort
-                    - protocol
-                    x-kubernetes-list-type: map
-                  readinessProbe:
-                    description: 'Periodic probe of container service readiness. Container
-                      will be removed from service endpoints if the probe fails. Cannot
-                      be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                    properties:
-                      exec:
-                        description: One and only one of the following should be specified.
-                          Exec specifies the action to take.
-                        properties:
-                          command:
-                            description: Command is the command line to execute inside
-                              the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      failureThreshold:
-                        description: Minimum consecutive failures for the probe to
-                          be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGet specifies the http request to perform.
-                        properties:
-                          host:
-                            description: Host name to connect to, defaults to the
-                              pod IP. You probably want to set "Host" in httpHeaders
-                              instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: The header field name
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Name or number of the port to access on the
-                              container. Number must be in the range 1 to 65535. Name
-                              must be an IANA_SVC_NAME.
-                            x-kubernetes-int-or-string: true
-                          scheme:
-                            description: Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: Minimum consecutive successes for the probe to
-                          be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: 'TCPSocket specifies an action involving a TCP
-                          port. TCP hooks not yet supported TODO: implement a realistic
-                          TCP lifecycle hook'
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Number or name of the port to access on the
-                              container. Number must be in the range 1 to 65535. Name
-                              must be an IANA_SVC_NAME.
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                    type: object
-                  resources:
-                    description: 'Compute Resources required by this container. Cannot
-                      be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                    type: object
-                  securityContext:
-                    description: 'Security options the pod should run with. More info:
-                      https://kubernetes.io/docs/concepts/policy/security-context/
-                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
-                    properties:
-                      allowPrivilegeEscalation:
-                        description: 'AllowPrivilegeEscalation controls whether a
-                          process can gain more privileges than its parent process.
-                          This bool directly controls if the no_new_privs flag will
-                          be set on the container process. AllowPrivilegeEscalation
-                          is true always when the container is: 1) run as Privileged
-                          2) has CAP_SYS_ADMIN'
-                        type: boolean
-                      capabilities:
-                        description: The capabilities to add/drop when running containers.
-                          Defaults to the default set of capabilities granted by the
-                          container runtime.
-                        properties:
-                          add:
-                            description: Added capabilities
-                            items:
-                              description: Capability represent POSIX capabilities
-                                type
-                              type: string
-                            type: array
-                          drop:
-                            description: Removed capabilities
-                            items:
-                              description: Capability represent POSIX capabilities
-                                type
-                              type: string
-                            type: array
-                        type: object
-                      privileged:
-                        description: Run container in privileged mode. Processes in
-                          privileged containers are essentially equivalent to root
-                          on the host. Defaults to false.
-                        type: boolean
-                      procMount:
-                        description: procMount denotes the type of proc mount to use
-                          for the containers. The default is DefaultProcMount which
-                          uses the container runtime defaults for readonly paths and
-                          masked paths. This requires the ProcMountType feature flag
-                          to be enabled.
-                        type: string
-                      readOnlyRootFilesystem:
-                        description: Whether this container has a read-only root filesystem.
-                          Default is false.
-                        type: boolean
-                      runAsGroup:
-                        description: The GID to run the entrypoint of the container
-                          process. Uses runtime default if unset. May also be set
-                          in PodSecurityContext.  If set in both SecurityContext and
-                          PodSecurityContext, the value specified in SecurityContext
-                          takes precedence.
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        description: Indicates that the container must run as a non-root
-                          user. If true, the Kubelet will validate the image at runtime
-                          to ensure that it does not run as UID 0 (root) and fail
-                          to start the container if it does. If unset or false, no
-                          such validation will be performed. May also be set in PodSecurityContext.  If
-                          set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
-                        type: boolean
-                      runAsUser:
-                        description: The UID to run the entrypoint of the container
-                          process. Defaults to user specified in image metadata if
-                          unspecified. May also be set in PodSecurityContext.  If
-                          set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        description: The SELinux context to be applied to the container.
-                          If unspecified, the container runtime will allocate a random
-                          SELinux context for each container.  May also be set in
-                          PodSecurityContext.  If set in both SecurityContext and
-                          PodSecurityContext, the value specified in SecurityContext
-                          takes precedence.
-                        properties:
-                          level:
-                            description: Level is SELinux level label that applies
-                              to the container.
-                            type: string
-                          role:
-                            description: Role is a SELinux role label that applies
-                              to the container.
-                            type: string
-                          type:
-                            description: Type is a SELinux type label that applies
-                              to the container.
-                            type: string
-                          user:
-                            description: User is a SELinux user label that applies
-                              to the container.
-                            type: string
-                        type: object
-                      windowsOptions:
-                        description: The Windows specific settings applied to all
-                          containers. If unspecified, the options from the PodSecurityContext
-                          will be used. If set in both SecurityContext and PodSecurityContext,
-                          the value specified in SecurityContext takes precedence.
-                        properties:
-                          gmsaCredentialSpec:
-                            description: GMSACredentialSpec is where the GMSA admission
-                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                              inlines the contents of the GMSA credential spec named
-                              by the GMSACredentialSpecName field. This field is alpha-level
-                              and is only honored by servers that enable the WindowsGMSA
-                              feature flag.
-                            type: string
-                          gmsaCredentialSpecName:
-                            description: GMSACredentialSpecName is the name of the
-                              GMSA credential spec to use. This field is alpha-level
-                              and is only honored by servers that enable the WindowsGMSA
-                              feature flag.
-                            type: string
-                          runAsUserName:
-                            description: The UserName in Windows to run the entrypoint
-                              of the container process. Defaults to the user specified
-                              in image metadata if unspecified. May also be set in
-                              PodSecurityContext. If set in both SecurityContext and
-                              PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. This field is beta-level and may be
-                              disabled with the WindowsRunAsUserName feature flag.
-                            type: string
-                        type: object
-                    type: object
-                  startupProbe:
-                    description: 'StartupProbe indicates that the Pod has successfully
-                      initialized. If specified, no other probes are executed until
-                      this completes successfully. If this probe fails, the Pod will
-                      be restarted, just as if the livenessProbe failed. This can
-                      be used to provide different probe parameters at the beginning
-                      of a Pod''s lifecycle, when it might take a long time to load
-                      data or warm a cache, than during steady-state operation. This
-                      cannot be updated. This is an alpha feature enabled by the StartupProbe
-                      feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                    properties:
-                      exec:
-                        description: One and only one of the following should be specified.
-                          Exec specifies the action to take.
-                        properties:
-                          command:
-                            description: Command is the command line to execute inside
-                              the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      failureThreshold:
-                        description: Minimum consecutive failures for the probe to
-                          be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGet specifies the http request to perform.
-                        properties:
-                          host:
-                            description: Host name to connect to, defaults to the
-                              pod IP. You probably want to set "Host" in httpHeaders
-                              instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: The header field name
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Name or number of the port to access on the
-                              container. Number must be in the range 1 to 65535. Name
-                              must be an IANA_SVC_NAME.
-                            x-kubernetes-int-or-string: true
-                          scheme:
-                            description: Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: Minimum consecutive successes for the probe to
-                          be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: 'TCPSocket specifies an action involving a TCP
-                          port. TCP hooks not yet supported TODO: implement a realistic
-                          TCP lifecycle hook'
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Number or name of the port to access on the
-                              container. Number must be in the range 1 to 65535. Name
-                              must be an IANA_SVC_NAME.
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                    type: object
-                  stdin:
-                    description: Whether this container should allocate a buffer for
-                      stdin in the container runtime. If this is not set, reads from
-                      stdin in the container will always result in EOF. Default is
-                      false.
-                    type: boolean
-                  stdinOnce:
-                    description: Whether the container runtime should close the stdin
-                      channel after it has been opened by a single attach. When stdin
-                      is true the stdin stream will remain open across multiple attach
-                      sessions. If stdinOnce is set to true, stdin is opened on container
-                      start, is empty until the first client attaches to stdin, and
-                      then remains open and accepts data until the client disconnects,
-                      at which time stdin is closed and remains closed until the container
-                      is restarted. If this flag is false, a container processes that
-                      reads from stdin will never receive an EOF. Default is false
-                    type: boolean
-                  tektonTask:
-                    description: TektonTask is for referring local Tasks or the Tasks
-                      registered in tekton catalog github repo.
-                    properties:
-                      params:
-                        description: Params are input params for the task
-                        items:
-                          description: Param declares an ArrayOrString to use for
-                            the parameter called name.
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              description: ArrayOrString is a type that can hold a
-                                single string or string array. Used in JSON unmarshalling
-                                so that a single JSON field can accept either an individual
-                                string or an array of strings.
-                              properties:
-                                arrayVal:
-                                  items:
-                                    type: string
-                                  type: array
-                                stringVal:
-                                  type: string
-                                type:
-                                  description: ParamType indicates the type of an
-                                    input parameter; Used to distinguish between a
-                                    single string and an array of strings.
-                                  type: string
-                              required:
-                              - arrayVal
-                              - stringVal
-                              - type
-                              type: object
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      resources:
-                        description: Resources are input/output resources for the
-                          task
-                        properties:
-                          inputs:
-                            description: Inputs holds the inputs resources this task
-                              was invoked with
-                            items:
-                              description: TaskResourceBinding points to the PipelineResource
-                                that will be used for the Task input or output called
-                                Name.
-                              properties:
-                                name:
-                                  description: Name is the name of the PipelineResource
-                                    in the Pipeline's declaration
-                                  type: string
-                                paths:
-                                  description: 'Paths will probably be removed in
-                                    #1284, and then PipelineResourceBinding can be
-                                    used instead. The optional Path field corresponds
-                                    to a path on disk at which the Resource can be
-                                    found (used when providing the resource via mounted
-                                    volume, overriding the default logic to fetch
-                                    the Resource).'
-                                  items:
-                                    type: string
-                                  type: array
-                                resourceRef:
-                                  description: ResourceRef is a reference to the instance
-                                    of the actual PipelineResource that should be
-                                    used
-                                  properties:
-                                    apiVersion:
-                                      description: API version of the referent
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent; More info:
-                                        http://kubernetes.io/docs/user-guide/identifiers#names'
-                                      type: string
-                                  type: object
-                                resourceSpec:
-                                  description: ResourceSpec is specification of a
-                                    resource that should be created and consumed by
-                                    the task
-                                  properties:
-                                    description:
-                                      description: Description is a user-facing description
-                                        of the resource that may be used to populate
-                                        a UI.
-                                      type: string
-                                    params:
-                                      items:
-                                        description: ResourceParam declares a string
-                                          value to use for the parameter called Name,
-                                          and is used in the specific context of PipelineResources.
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    secrets:
-                                      description: Secrets to fetch to populate some
-                                        of resource fields
-                                      items:
-                                        description: SecretParam indicates which secret
-                                          can be used to populate a field of the resource
-                                        properties:
-                                          fieldName:
-                                            type: string
-                                          secretKey:
-                                            type: string
-                                          secretName:
-                                            type: string
-                                        required:
-                                        - fieldName
-                                        - secretKey
-                                        - secretName
-                                        type: object
-                                      type: array
-                                    type:
-                                      type: string
-                                  required:
-                                  - params
-                                  - type
-                                  type: object
-                              type: object
-                            type: array
-                          outputs:
-                            description: Outputs holds the inputs resources this task
-                              was invoked with
-                            items:
-                              description: TaskResourceBinding points to the PipelineResource
-                                that will be used for the Task input or output called
-                                Name.
-                              properties:
-                                name:
-                                  description: Name is the name of the PipelineResource
-                                    in the Pipeline's declaration
-                                  type: string
-                                paths:
-                                  description: 'Paths will probably be removed in
-                                    #1284, and then PipelineResourceBinding can be
-                                    used instead. The optional Path field corresponds
-                                    to a path on disk at which the Resource can be
-                                    found (used when providing the resource via mounted
-                                    volume, overriding the default logic to fetch
-                                    the Resource).'
-                                  items:
-                                    type: string
-                                  type: array
-                                resourceRef:
-                                  description: ResourceRef is a reference to the instance
-                                    of the actual PipelineResource that should be
-                                    used
-                                  properties:
-                                    apiVersion:
-                                      description: API version of the referent
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent; More info:
-                                        http://kubernetes.io/docs/user-guide/identifiers#names'
-                                      type: string
-                                  type: object
-                                resourceSpec:
-                                  description: ResourceSpec is specification of a
-                                    resource that should be created and consumed by
-                                    the task
-                                  properties:
-                                    description:
-                                      description: Description is a user-facing description
-                                        of the resource that may be used to populate
-                                        a UI.
-                                      type: string
-                                    params:
-                                      items:
-                                        description: ResourceParam declares a string
-                                          value to use for the parameter called Name,
-                                          and is used in the specific context of PipelineResources.
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    secrets:
-                                      description: Secrets to fetch to populate some
-                                        of resource fields
-                                      items:
-                                        description: SecretParam indicates which secret
-                                          can be used to populate a field of the resource
-                                        properties:
-                                          fieldName:
-                                            type: string
-                                          secretKey:
-                                            type: string
-                                          secretName:
-                                            type: string
-                                        required:
-                                        - fieldName
-                                        - secretKey
-                                        - secretName
-                                        type: object
-                                      type: array
-                                    type:
-                                      type: string
-                                  required:
-                                  - params
-                                  - type
-                                  type: object
-                              type: object
-                            type: array
-                        type: object
-                      taskRef:
-                        description: TaskRef refers to the existing Task in local
-                          cluster or to the tekton catalog github repo.
-                        properties:
-                          catalog:
-                            description: 'Catalog is a name of the task @ tekton catalog
-                              github repo. (e.g., s2i@0.2) FYI: https://github.com/tektoncd/catalog'
-                            type: string
-                          name:
-                            description: Name for local Tasks
-                            type: string
-                        required:
-                        - catalog
-                        - name
-                        type: object
-                      workspaces:
-                        description: Workspaces are workspaces for the task
-                        items:
-                          description: WorkspaceBinding maps a Task's declared workspace
-                            to a Volume.
-                          properties:
-                            configMap:
-                              description: ConfigMap represents a configMap that should
-                                populate this workspace.
-                              properties:
-                                defaultMode:
-                                  description: 'Optional: mode bits to use on created
-                                    files by default. Must be a value between 0 and
-                                    0777. Defaults to 0644. Directories within the
-                                    path are not affected by this setting. This might
-                                    be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
-                                  type: boolean
-                              type: object
-                            emptyDir:
-                              description: 'EmptyDir represents a temporary directory
-                                that shares a Task''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
-                                Either this OR PersistentVolumeClaim can be used.'
-                              properties:
-                                medium:
-                                  description: 'What type of storage medium should
-                                    back this directory. The default is "" which means
-                                    to use the node''s default medium. Must be an
-                                    empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                  type: string
-                                sizeLimit:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: 'Total amount of local storage required
-                                    for this EmptyDir volume. The size limit is also
-                                    applicable for memory medium. The maximum usage
-                                    on memory medium EmptyDir would be the minimum
-                                    value between the SizeLimit specified here and
-                                    the sum of memory limits of all containers in
-                                    a pod. The default is nil which means that the
-                                    limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              type: object
-                            name:
-                              description: Name is the name of the workspace populated
-                                by the volume.
-                              type: string
-                            persistentVolumeClaim:
-                              description: PersistentVolumeClaimVolumeSource represents
-                                a reference to a PersistentVolumeClaim in the same
-                                namespace. Either this OR EmptyDir can be used.
-                              properties:
-                                claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim
-                                    in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                  type: string
-                                readOnly:
-                                  description: Will force the ReadOnly setting in
-                                    VolumeMounts. Default false.
-                                  type: boolean
-                              required:
-                              - claimName
-                              type: object
-                            secret:
-                              description: Secret represents a secret that should
-                                populate this workspace.
-                              properties:
-                                defaultMode:
-                                  description: 'Optional: mode bits to use on created
-                                    files by default. Must be a value between 0 and
-                                    0777. Defaults to 0644. Directories within the
-                                    path are not affected by this setting. This might
-                                    be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                optional:
-                                  description: Specify whether the Secret or its keys
-                                    must be defined
-                                  type: boolean
-                                secretName:
-                                  description: 'Name of the secret in the pod''s namespace
-                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                                  type: string
-                              type: object
-                            subPath:
-                              description: SubPath is optionally a directory on the
-                                volume which should be used for this binding (i.e.
-                                the volume will be mounted at this sub directory).
-                              type: string
-                            volumeClaimTemplate:
-                              description: VolumeClaimTemplate is a template for a
-                                claim that will be created in the same namespace.
-                                The PipelineRun controller is responsible for creating
-                                a unique claim for each instance of PipelineRun.
-                              properties:
-                                apiVersion:
-                                  description: 'APIVersion defines the versioned schema
-                                    of this representation of an object. Servers should
-                                    convert recognized schemas to the latest internal
-                                    value, and may reject unrecognized values. More
-                                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                                  type: string
-                                kind:
-                                  description: 'Kind is a string value representing
-                                    the REST resource this object represents. Servers
-                                    may infer this from the endpoint the client submits
-                                    requests to. Cannot be updated. In CamelCase.
-                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                                  type: string
-                                metadata:
-                                  description: 'Standard object''s metadata. More
-                                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                                  type: object
-                                spec:
-                                  description: 'Spec defines the desired characteristics
-                                    of a volume requested by a pod author. More info:
-                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                  properties:
-                                    accessModes:
-                                      description: 'AccessModes contains the desired
-                                        access modes the volume should have. More
-                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                      items:
-                                        type: string
-                                      type: array
-                                    dataSource:
-                                      description: This field requires the VolumeSnapshotDataSource
-                                        alpha feature gate to be enabled and currently
-                                        VolumeSnapshot is the only supported data
-                                        source. If the provisioner can support VolumeSnapshot
-                                        data source, it will create a new volume and
-                                        data will be restored to the volume at the
-                                        same time. If the provisioner does not support
-                                        VolumeSnapshot data source, volume will not
-                                        be created and the failure will be reported
-                                        as an event. In the future, we plan to support
-                                        more data source types and the behavior of
-                                        the provisioner may change.
-                                      properties:
-                                        apiGroup:
-                                          description: APIGroup is the group for the
-                                            resource being referenced. If APIGroup
-                                            is not specified, the specified Kind must
-                                            be in the core API group. For any other
-                                            third-party types, APIGroup is required.
-                                          type: string
-                                        kind:
-                                          description: Kind is the type of resource
-                                            being referenced
-                                          type: string
-                                        name:
-                                          description: Name is the name of resource
-                                            being referenced
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    resources:
-                                      description: 'Resources represents the minimum
-                                        resources the volume should have. More info:
-                                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                          type: object
-                                      type: object
-                                    selector:
-                                      description: A label query over volumes to consider
-                                        for binding.
-                                      properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
-                                          items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key
-                                                  that the selector applies to.
-                                                type: string
-                                              operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
-                                          type: object
-                                      type: object
-                                    storageClassName:
-                                      description: 'Name of the StorageClass required
-                                        by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                      type: string
-                                    volumeMode:
-                                      description: volumeMode defines what type of
-                                        volume is required by the claim. Value of
-                                        Filesystem is implied when not included in
-                                        claim spec. This is a beta feature.
-                                      type: string
-                                    volumeName:
-                                      description: VolumeName is the binding reference
-                                        to the PersistentVolume backing this claim.
-                                      type: string
-                                  type: object
-                                status:
-                                  description: 'Status represents the current information/status
-                                    of a persistent volume claim. Read-only. More
-                                    info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                  properties:
-                                    accessModes:
-                                      description: 'AccessModes contains the actual
-                                        access modes the volume backing the PVC has.
-                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                      items:
-                                        type: string
-                                      type: array
-                                    capacity:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description: Represents the actual resources
-                                        of the underlying volume.
-                                      type: object
-                                    conditions:
-                                      description: Current Condition of persistent
-                                        volume claim. If underlying persistent volume
-                                        is being resized then the Condition will be
-                                        set to 'ResizeStarted'.
-                                      items:
-                                        description: PersistentVolumeClaimCondition
-                                          contails details about state of pvc
-                                        properties:
-                                          lastProbeTime:
-                                            description: Last time we probed the condition.
-                                            format: date-time
-                                            type: string
-                                          lastTransitionTime:
-                                            description: Last time the condition transitioned
-                                              from one status to another.
-                                            format: date-time
-                                            type: string
-                                          message:
-                                            description: Human-readable message indicating
-                                              details about last transition.
-                                            type: string
-                                          reason:
-                                            description: Unique, this should be a
-                                              short, machine understandable string
-                                              that gives the reason for condition's
-                                              last transition. If it reports "ResizeStarted"
-                                              that means the underlying persistent
-                                              volume is being resized.
-                                            type: string
-                                          status:
-                                            type: string
-                                          type:
-                                            description: PersistentVolumeClaimConditionType
-                                              is a valid value of PersistentVolumeClaimCondition.Type
-                                            type: string
-                                        required:
-                                        - status
-                                        - type
-                                        type: object
-                                      type: array
-                                    phase:
-                                      description: Phase represents the current phase
-                                        of PersistentVolumeClaim.
-                                      type: string
-                                  type: object
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                    required:
-                    - params
-                    - taskRef
-                    - workspaces
-                    type: object
-                  terminationMessagePath:
-                    description: 'Optional: Path at which the file to which the container''s
-                      termination message will be written is mounted into the container''s
-                      filesystem. Message written is intended to be brief final status,
-                      such as an assertion failure message. Will be truncated by the
-                      node if greater than 4096 bytes. The total message length across
-                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
-                      Cannot be updated.'
-                    type: string
-                  terminationMessagePolicy:
-                    description: Indicate how the termination message should be populated.
-                      File will use the contents of terminationMessagePath to populate
-                      the container status message on both success and failure. FallbackToLogsOnError
-                      will use the last chunk of container log output if the termination
-                      message file is empty and the container exited with an error.
-                      The log output is limited to 2048 bytes or 80 lines, whichever
-                      is smaller. Defaults to File. Cannot be updated.
-                    type: string
-                  tty:
-                    description: Whether this container should allocate a TTY for
-                      itself, also requires 'stdin' to be true. Default is false.
-                    type: boolean
-                  volumeDevices:
-                    description: volumeDevices is the list of block devices to be
-                      used by the container. This is a beta feature.
-                    items:
-                      description: volumeDevice describes a mapping of a raw block
-                        device within a container.
-                      properties:
-                        devicePath:
-                          description: devicePath is the path inside of the container
-                            that the device will be mapped to.
-                          type: string
-                        name:
-                          description: name must match the name of a persistentVolumeClaim
-                            in the pod
-                          type: string
-                      required:
-                      - devicePath
-                      - name
-                      type: object
-                    type: array
-                  volumeMounts:
-                    description: Pod volumes to mount into the container's filesystem.
-                      Cannot be updated.
-                    items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
-                      properties:
-                        mountPath:
-                          description: Path within the container at which the volume
-                            should be mounted.  Must not contain ':'.
-                          type: string
-                        mountPropagation:
-                          description: mountPropagation determines how mounts are
-                            propagated from the host to container and the other way
-                            around. When not set, MountPropagationNone is used. This
-                            field is beta in 1.10.
-                          type: string
-                        name:
-                          description: This must match the Name of a Volume.
-                          type: string
-                        readOnly:
-                          description: Mounted read-only if true, read-write otherwise
-                            (false or unspecified). Defaults to false.
-                          type: boolean
-                        subPath:
-                          description: Path within the volume from which the container's
-                            volume should be mounted. Defaults to "" (volume's root).
-                          type: string
-                        subPathExpr:
-                          description: Expanded path within the volume from which
-                            the container's volume should be mounted. Behaves similarly
-                            to SubPath but environment variable references $(VAR_NAME)
-                            are expanded using the container's environment. Defaults
-                            to "" (volume's root). SubPathExpr and SubPath are mutually
-                            exclusive.
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                      type: object
-                    type: array
-                  when:
-                    description: When is condition for running the job
-                    properties:
-                      branch:
-                        items:
-                          type: string
-                        type: array
-                      ref:
-                        items:
-                          type: string
-                        type: array
-                      skipBranch:
-                        items:
-                          type: string
-                        type: array
-                      skipRef:
-                        items:
-                          type: string
-                        type: array
-                      skipTag:
-                        items:
-                          type: string
-                        type: array
-                      tag:
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - branch
-                    - ref
-                    - skipBranch
-                    - skipRef
-                    - skipTag
-                    - tag
-                    type: object
-                  workingDir:
-                    description: Container's working directory. If not specified,
-                      the container runtime's default will be used, which might be
-                      configured in the container image. Cannot be updated.
-                    type: string
-                required:
-                - after
-                - name
-                type: object
-              type: array
-            refs:
-              description: Refs
-              properties:
-                base:
-                  description: Base is a base pointer for base commit for the pull
-                    request If Pull is nil (i.e., is push event), Base works as Head
-                  properties:
-                    link:
-                      type: string
-                    ref:
-                      type: string
-                    sha:
-                      type: string
-                  required:
-                  - link
-                  - ref
-                  - sha
-                  type: object
-                link:
-                  description: Link is a full url of the repository
-                  type: string
-                pull:
-                  description: Pull represents pull request head commit
-                  properties:
-                    author:
-                      properties:
-                        link:
-                          type: string
-                        name:
-                          type: string
-                      required:
-                      - link
-                      - name
-                      type: object
-                    id:
-                      type: integer
-                    link:
-                      type: string
-                    sha:
-                      type: string
-                  required:
-                  - author
-                  - id
-                  - link
-                  - sha
-                  type: object
-                repository:
-                  description: Repository name of git repository (in <org>/<repo>
-                    form, e.g., tmax-cloud/cicd-operator)
-                  pattern: .+/.+
-                  type: string
-              required:
-              - base
-              - link
-              - repository
-              type: object
-          required:
-          - configRef
-          - id
-          - jobs
-          - refs
-          type: object
-        status:
-          description: IntegrationJobStatus defines the observed state of IntegrationJob
-          properties:
-            state:
-              description: State is a current state of the IntegrationJob
-              type: string
-          required:
-          - state
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: IntegrationJob is the Schema for the integrationjobs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IntegrationJobSpec defines the desired state of IntegrationJob
+            properties:
+              configRef:
+                description: ConfigRef refers to the corresponding IntegrationConfig
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - name
+                - type
+                type: object
+              id:
+                description: Id is a unique random string for the IntegrationJob
+                type: string
+              jobs:
+                description: Jobs are the tasks to be executed
+                items:
+                  properties:
+                    after:
+                      description: After configures which jobs should be executed
+                        before this job runs
+                      items:
+                        type: string
+                      type: array
+                    args:
+                      description: 'Arguments to the entrypoint. The docker image''s
+                        CMD is used if this is not provided. Variable references $(VAR_NAME)
+                        are expanded using the container''s environment. If a variable
+                        cannot be resolved, the reference in the input string will
+                        be unchanged. The $(VAR_NAME) syntax can be escaped with a
+                        double $$, ie: $$(VAR_NAME). Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      items:
+                        type: string
+                      type: array
+                    command:
+                      description: 'Entrypoint array. Not executed within a shell.
+                        The docker image''s ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container''s
+                        environment. If a variable cannot be resolved, the reference
+                        in the input string will be unchanged. The $(VAR_NAME) syntax
+                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                        references will never be expanded, regardless of whether the
+                        variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      items:
+                        type: string
+                      type: array
+                    env:
+                      description: List of environment variables to set in the container.
+                        Cannot be updated.
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previous defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. The $(VAR_NAME) syntax
+                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, metadata.labels,
+                                  metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                  status.hostIP, status.podIP, status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    envFrom:
+                      description: List of sources to populate environment variables
+                        in the container. The keys defined within a source must be
+                        a C_IDENTIFIER. All invalid keys will be reported as an event
+                        when the container is starting. When a key exists in multiple
+                        sources, the value associated with the last source will take
+                        precedence. Values defined by an Env with a duplicate key
+                        will take precedence. Cannot be updated.
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                          prefix:
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                        type: object
+                      type: array
+                    image:
+                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management
+                        to default or override container images in workload controllers
+                        like Deployments and StatefulSets.'
+                      type: string
+                    imagePullPolicy:
+                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent
+                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                      type: string
+                    lifecycle:
+                      description: Actions that the management system should take
+                        in response to container lifecycle events. Cannot be updated.
+                      properties:
+                        postStart:
+                          description: 'PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy. Other management
+                            of the container blocks until the hook completes. More
+                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                        preStop:
+                          description: 'PreStop is called immediately before a container
+                            is terminated due to an API request or management event
+                            such as liveness/startup probe failure, preemption, resource
+                            contention, etc. The handler is not called if the container
+                            crashes or exits. The reason for termination is passed
+                            to the handler. The Pod''s termination grace period countdown
+                            begins before the PreStop hooked is executed. Regardless
+                            of the outcome of the handler, the container will eventually
+                            terminate within the Pod''s termination grace period.
+                            Other management of the container blocks until the hook
+                            completes or until the termination grace period is reached.
+                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                      type: object
+                    livenessProbe:
+                      description: 'Periodic probe of container liveness. Container
+                        will be restarted if the probe fails. Cannot be updated. More
+                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    name:
+                      description: Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
+                      type: string
+                    ports:
+                      description: List of ports to expose from the container. Exposing
+                        a port here gives the system additional information about
+                        the network connections a container uses, but is primarily
+                        informational. Not specifying a port here DOES NOT prevent
+                        that port from being exposed. Any port which is listening
+                        on the default "0.0.0.0" address inside a container will be
+                        accessible from the network. Cannot be updated.
+                      items:
+                        description: ContainerPort represents a network port in a
+                          single container.
+                        properties:
+                          containerPort:
+                            description: Number of port to expose on the pod's IP
+                              address. This must be a valid port number, 0 < x < 65536.
+                            format: int32
+                            type: integer
+                          hostIP:
+                            description: What host IP to bind the external port to.
+                            type: string
+                          hostPort:
+                            description: Number of port to expose on the host. If
+                              specified, this must be a valid port number, 0 < x <
+                              65536. If HostNetwork is specified, this must match
+                              ContainerPort. Most containers do not need this.
+                            format: int32
+                            type: integer
+                          name:
+                            description: If specified, this must be an IANA_SVC_NAME
+                              and unique within the pod. Each named port in a pod
+                              must have a unique name. Name for the port that can
+                              be referred to by services.
+                            type: string
+                          protocol:
+                            default: TCP
+                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
+                            type: string
+                        required:
+                        - containerPort
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
+                    readinessProbe:
+                      description: 'Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe
+                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    resources:
+                      description: 'Compute Resources required by this container.
+                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    securityContext:
+                      description: 'Security options the pod should run with. More
+                        info: https://kubernetes.io/docs/concepts/policy/security-context/
+                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN'
+                          type: boolean
+                        capabilities:
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false.
+                          type: boolean
+                        procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths. This requires the ProcMountType
+                            feature flag to be enabled.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false.
+                          type: boolean
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both
+                            SecurityContext and PodSecurityContext, the value specified
+                            in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field. This field is
+                                alpha-level and is only honored by servers that enable
+                                the WindowsGMSA feature flag.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use. This field is alpha-level
+                                and is only honored by servers that enable the WindowsGMSA
+                                feature flag.
+                              type: string
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. This field is beta-level and may
+                                be disabled with the WindowsRunAsUserName feature
+                                flag.
+                              type: string
+                          type: object
+                      type: object
+                    startupProbe:
+                      description: 'StartupProbe indicates that the Pod has successfully
+                        initialized. If specified, no other probes are executed until
+                        this completes successfully. If this probe fails, the Pod
+                        will be restarted, just as if the livenessProbe failed. This
+                        can be used to provide different probe parameters at the beginning
+                        of a Pod''s lifecycle, when it might take a long time to load
+                        data or warm a cache, than during steady-state operation.
+                        This cannot be updated. This is an alpha feature enabled by
+                        the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime. If this is not set, reads
+                        from stdin in the container will always result in EOF. Default
+                        is false.
+                      type: boolean
+                    stdinOnce:
+                      description: Whether the container runtime should close the
+                        stdin channel after it has been opened by a single attach.
+                        When stdin is true the stdin stream will remain open across
+                        multiple attach sessions. If stdinOnce is set to true, stdin
+                        is opened on container start, is empty until the first client
+                        attaches to stdin, and then remains open and accepts data
+                        until the client disconnects, at which time stdin is closed
+                        and remains closed until the container is restarted. If this
+                        flag is false, a container processes that reads from stdin
+                        will never receive an EOF. Default is false
+                      type: boolean
+                    tektonTask:
+                      description: TektonTask is for referring local Tasks or the
+                        Tasks registered in tekton catalog github repo.
+                      properties:
+                        params:
+                          description: Params are input params for the task
+                          items:
+                            description: Param declares an ArrayOrString to use for
+                              the parameter called name.
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                description: ArrayOrString is a type that can hold
+                                  a single string or string array. Used in JSON unmarshalling
+                                  so that a single JSON field can accept either an
+                                  individual string or an array of strings.
+                                properties:
+                                  arrayVal:
+                                    items:
+                                      type: string
+                                    type: array
+                                  stringVal:
+                                    type: string
+                                  type:
+                                    description: ParamType indicates the type of an
+                                      input parameter; Used to distinguish between
+                                      a single string and an array of strings.
+                                    type: string
+                                required:
+                                - arrayVal
+                                - stringVal
+                                - type
+                                type: object
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        resources:
+                          description: Resources are input/output resources for the
+                            task
+                          properties:
+                            inputs:
+                              description: Inputs holds the inputs resources this
+                                task was invoked with
+                              items:
+                                description: TaskResourceBinding points to the PipelineResource
+                                  that will be used for the Task input or output called
+                                  Name.
+                                properties:
+                                  name:
+                                    description: Name is the name of the PipelineResource
+                                      in the Pipeline's declaration
+                                    type: string
+                                  paths:
+                                    description: 'Paths will probably be removed in
+                                      #1284, and then PipelineResourceBinding can
+                                      be used instead. The optional Path field corresponds
+                                      to a path on disk at which the Resource can
+                                      be found (used when providing the resource via
+                                      mounted volume, overriding the default logic
+                                      to fetch the Resource).'
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourceRef:
+                                    description: ResourceRef is a reference to the
+                                      instance of the actual PipelineResource that
+                                      should be used
+                                    properties:
+                                      apiVersion:
+                                        description: API version of the referent
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent; More info:
+                                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                                        type: string
+                                    type: object
+                                  resourceSpec:
+                                    description: ResourceSpec is specification of
+                                      a resource that should be created and consumed
+                                      by the task
+                                    properties:
+                                      description:
+                                        description: Description is a user-facing
+                                          description of the resource that may be
+                                          used to populate a UI.
+                                        type: string
+                                      params:
+                                        items:
+                                          description: ResourceParam declares a string
+                                            value to use for the parameter called
+                                            Name, and is used in the specific context
+                                            of PipelineResources.
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      secrets:
+                                        description: Secrets to fetch to populate
+                                          some of resource fields
+                                        items:
+                                          description: SecretParam indicates which
+                                            secret can be used to populate a field
+                                            of the resource
+                                          properties:
+                                            fieldName:
+                                              type: string
+                                            secretKey:
+                                              type: string
+                                            secretName:
+                                              type: string
+                                          required:
+                                          - fieldName
+                                          - secretKey
+                                          - secretName
+                                          type: object
+                                        type: array
+                                      type:
+                                        type: string
+                                    required:
+                                    - params
+                                    - type
+                                    type: object
+                                type: object
+                              type: array
+                            outputs:
+                              description: Outputs holds the inputs resources this
+                                task was invoked with
+                              items:
+                                description: TaskResourceBinding points to the PipelineResource
+                                  that will be used for the Task input or output called
+                                  Name.
+                                properties:
+                                  name:
+                                    description: Name is the name of the PipelineResource
+                                      in the Pipeline's declaration
+                                    type: string
+                                  paths:
+                                    description: 'Paths will probably be removed in
+                                      #1284, and then PipelineResourceBinding can
+                                      be used instead. The optional Path field corresponds
+                                      to a path on disk at which the Resource can
+                                      be found (used when providing the resource via
+                                      mounted volume, overriding the default logic
+                                      to fetch the Resource).'
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourceRef:
+                                    description: ResourceRef is a reference to the
+                                      instance of the actual PipelineResource that
+                                      should be used
+                                    properties:
+                                      apiVersion:
+                                        description: API version of the referent
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent; More info:
+                                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                                        type: string
+                                    type: object
+                                  resourceSpec:
+                                    description: ResourceSpec is specification of
+                                      a resource that should be created and consumed
+                                      by the task
+                                    properties:
+                                      description:
+                                        description: Description is a user-facing
+                                          description of the resource that may be
+                                          used to populate a UI.
+                                        type: string
+                                      params:
+                                        items:
+                                          description: ResourceParam declares a string
+                                            value to use for the parameter called
+                                            Name, and is used in the specific context
+                                            of PipelineResources.
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      secrets:
+                                        description: Secrets to fetch to populate
+                                          some of resource fields
+                                        items:
+                                          description: SecretParam indicates which
+                                            secret can be used to populate a field
+                                            of the resource
+                                          properties:
+                                            fieldName:
+                                              type: string
+                                            secretKey:
+                                              type: string
+                                            secretName:
+                                              type: string
+                                          required:
+                                          - fieldName
+                                          - secretKey
+                                          - secretName
+                                          type: object
+                                        type: array
+                                      type:
+                                        type: string
+                                    required:
+                                    - params
+                                    - type
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        taskRef:
+                          description: TaskRef refers to the existing Task in local
+                            cluster or to the tekton catalog github repo.
+                          properties:
+                            catalog:
+                              description: 'Catalog is a name of the task @ tekton
+                                catalog github repo. (e.g., s2i@0.2) FYI: https://github.com/tektoncd/catalog'
+                              type: string
+                            name:
+                              description: Name for local Tasks
+                              type: string
+                          required:
+                          - catalog
+                          - name
+                          type: object
+                        workspaces:
+                          description: Workspaces are workspaces for the task
+                          items:
+                            description: WorkspaceBinding maps a Task's declared workspace
+                              to a Volume.
+                            properties:
+                              configMap:
+                                description: ConfigMap represents a configMap that
+                                  should populate this workspace.
+                                properties:
+                                  defaultMode:
+                                    description: 'Optional: mode bits to use on created
+                                      files by default. Must be a value between 0
+                                      and 0777. Defaults to 0644. Directories within
+                                      the path are not affected by this setting. This
+                                      might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the
+                                      result can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its keys must be defined
+                                    type: boolean
+                                type: object
+                              emptyDir:
+                                description: 'EmptyDir represents a temporary directory
+                                  that shares a Task''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                  Either this OR PersistentVolumeClaim can be used.'
+                                properties:
+                                  medium:
+                                    description: 'What type of storage medium should
+                                      back this directory. The default is "" which
+                                      means to use the node''s default medium. Must
+                                      be an empty string (default) or Memory. More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    type: string
+                                  sizeLimit:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'Total amount of local storage required
+                                      for this EmptyDir volume. The size limit is
+                                      also applicable for memory medium. The maximum
+                                      usage on memory medium EmptyDir would be the
+                                      minimum value between the SizeLimit specified
+                                      here and the sum of memory limits of all containers
+                                      in a pod. The default is nil which means that
+                                      the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              name:
+                                description: Name is the name of the workspace populated
+                                  by the volume.
+                                type: string
+                              persistentVolumeClaim:
+                                description: PersistentVolumeClaimVolumeSource represents
+                                  a reference to a PersistentVolumeClaim in the same
+                                  namespace. Either this OR EmptyDir can be used.
+                                properties:
+                                  claimName:
+                                    description: 'ClaimName is the name of a PersistentVolumeClaim
+                                      in the same namespace as the pod using this
+                                      volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    type: string
+                                  readOnly:
+                                    description: Will force the ReadOnly setting in
+                                      VolumeMounts. Default false.
+                                    type: boolean
+                                required:
+                                - claimName
+                                type: object
+                              secret:
+                                description: Secret represents a secret that should
+                                  populate this workspace.
+                                properties:
+                                  defaultMode:
+                                    description: 'Optional: mode bits to use on created
+                                      files by default. Must be a value between 0
+                                      and 0777. Defaults to 0644. Directories within
+                                      the path are not affected by this setting. This
+                                      might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the
+                                      result can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced Secret will
+                                      be projected into the volume as a file whose
+                                      name is the key and content is the value. If
+                                      specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: The key to project.
+                                          type: string
+                                        mode:
+                                          description: 'Optional: mode bits to use
+                                            on this file, must be a value between
+                                            0 and 0777. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: 'Name of the secret in the pod''s
+                                      namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    type: string
+                                type: object
+                              subPath:
+                                description: SubPath is optionally a directory on
+                                  the volume which should be used for this binding
+                                  (i.e. the volume will be mounted at this sub directory).
+                                type: string
+                              volumeClaimTemplate:
+                                description: VolumeClaimTemplate is a template for
+                                  a claim that will be created in the same namespace.
+                                  The PipelineRun controller is responsible for creating
+                                  a unique claim for each instance of PipelineRun.
+                                properties:
+                                  apiVersion:
+                                    description: 'APIVersion defines the versioned
+                                      schema of this representation of an object.
+                                      Servers should convert recognized schemas to
+                                      the latest internal value, and may reject unrecognized
+                                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                    type: string
+                                  kind:
+                                    description: 'Kind is a string value representing
+                                      the REST resource this object represents. Servers
+                                      may infer this from the endpoint the client
+                                      submits requests to. Cannot be updated. In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  metadata:
+                                    description: 'Standard object''s metadata. More
+                                      info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                    type: object
+                                  spec:
+                                    description: 'Spec defines the desired characteristics
+                                      of a volume requested by a pod author. More
+                                      info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    properties:
+                                      accessModes:
+                                        description: 'AccessModes contains the desired
+                                          access modes the volume should have. More
+                                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        description: This field requires the VolumeSnapshotDataSource
+                                          alpha feature gate to be enabled and currently
+                                          VolumeSnapshot is the only supported data
+                                          source. If the provisioner can support VolumeSnapshot
+                                          data source, it will create a new volume
+                                          and data will be restored to the volume
+                                          at the same time. If the provisioner does
+                                          not support VolumeSnapshot data source,
+                                          volume will not be created and the failure
+                                          will be reported as an event. In the future,
+                                          we plan to support more data source types
+                                          and the behavior of the provisioner may
+                                          change.
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        description: 'Resources represents the minimum
+                                          resources the volume should have. More info:
+                                          https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum
+                                              amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum
+                                              amount of compute resources required.
+                                              If Requests is omitted for a container,
+                                              it defaults to Limits if that is explicitly
+                                              specified, otherwise to an implementation-defined
+                                              value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: A label query over volumes to
+                                          consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        description: 'Name of the StorageClass required
+                                          by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeMode:
+                                        description: volumeMode defines what type
+                                          of volume is required by the claim. Value
+                                          of Filesystem is implied when not included
+                                          in claim spec. This is a beta feature.
+                                        type: string
+                                      volumeName:
+                                        description: VolumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                  status:
+                                    description: 'Status represents the current information/status
+                                      of a persistent volume claim. Read-only. More
+                                      info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    properties:
+                                      accessModes:
+                                        description: 'AccessModes contains the actual
+                                          access modes the volume backing the PVC
+                                          has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        items:
+                                          type: string
+                                        type: array
+                                      capacity:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: Represents the actual resources
+                                          of the underlying volume.
+                                        type: object
+                                      conditions:
+                                        description: Current Condition of persistent
+                                          volume claim. If underlying persistent volume
+                                          is being resized then the Condition will
+                                          be set to 'ResizeStarted'.
+                                        items:
+                                          description: PersistentVolumeClaimCondition
+                                            contails details about state of pvc
+                                          properties:
+                                            lastProbeTime:
+                                              description: Last time we probed the
+                                                condition.
+                                              format: date-time
+                                              type: string
+                                            lastTransitionTime:
+                                              description: Last time the condition
+                                                transitioned from one status to another.
+                                              format: date-time
+                                              type: string
+                                            message:
+                                              description: Human-readable message
+                                                indicating details about last transition.
+                                              type: string
+                                            reason:
+                                              description: Unique, this should be
+                                                a short, machine understandable string
+                                                that gives the reason for condition's
+                                                last transition. If it reports "ResizeStarted"
+                                                that means the underlying persistent
+                                                volume is being resized.
+                                              type: string
+                                            status:
+                                              type: string
+                                            type:
+                                              description: PersistentVolumeClaimConditionType
+                                                is a valid value of PersistentVolumeClaimCondition.Type
+                                              type: string
+                                          required:
+                                          - status
+                                          - type
+                                          type: object
+                                        type: array
+                                      phase:
+                                        description: Phase represents the current
+                                          phase of PersistentVolumeClaim.
+                                        type: string
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      required:
+                      - params
+                      - taskRef
+                      - workspaces
+                      type: object
+                    terminationMessagePath:
+                      description: 'Optional: Path at which the file to which the
+                        container''s termination message will be written is mounted
+                        into the container''s filesystem. Message written is intended
+                        to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes.
+                        The total message length across all containers will be limited
+                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                      type: string
+                    terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated. File will use the contents of terminationMessagePath
+                        to populate the container status message on both success and
+                        failure. FallbackToLogsOnError will use the last chunk of
+                        container log output if the termination message file is empty
+                        and the container exited with an error. The log output is
+                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
+                        to File. Cannot be updated.
+                      type: string
+                    tty:
+                      description: Whether this container should allocate a TTY for
+                        itself, also requires 'stdin' to be true. Default is false.
+                      type: boolean
+                    volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container. This is a beta feature.
+                      items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
+                        properties:
+                          devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
+                            type: string
+                          name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
+                            type: string
+                        required:
+                        - devicePath
+                        - name
+                        type: object
+                      type: array
+                    volumeMounts:
+                      description: Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                    when:
+                      description: When is condition for running the job
+                      properties:
+                        branch:
+                          items:
+                            type: string
+                          type: array
+                        ref:
+                          items:
+                            type: string
+                          type: array
+                        skipBranch:
+                          items:
+                            type: string
+                          type: array
+                        skipRef:
+                          items:
+                            type: string
+                          type: array
+                        skipTag:
+                          items:
+                            type: string
+                          type: array
+                        tag:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - branch
+                      - ref
+                      - skipBranch
+                      - skipRef
+                      - skipTag
+                      - tag
+                      type: object
+                    workingDir:
+                      description: Container's working directory. If not specified,
+                        the container runtime's default will be used, which might
+                        be configured in the container image. Cannot be updated.
+                      type: string
+                  required:
+                  - after
+                  - name
+                  type: object
+                type: array
+              refs:
+                description: Refs
+                properties:
+                  base:
+                    description: Base is a base pointer for base commit for the pull
+                      request If Pull is nil (i.e., is push event), Base works as
+                      Head
+                    properties:
+                      link:
+                        type: string
+                      ref:
+                        type: string
+                      sha:
+                        type: string
+                    required:
+                    - link
+                    - ref
+                    - sha
+                    type: object
+                  link:
+                    description: Link is a full url of the repository
+                    type: string
+                  pull:
+                    description: Pull represents pull request head commit
+                    properties:
+                      author:
+                        properties:
+                          link:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - link
+                        - name
+                        type: object
+                      id:
+                        type: integer
+                      link:
+                        type: string
+                      sha:
+                        type: string
+                    required:
+                    - author
+                    - id
+                    - link
+                    - sha
+                    type: object
+                  repository:
+                    description: Repository name of git repository (in <org>/<repo>
+                      form, e.g., tmax-cloud/cicd-operator)
+                    pattern: .+/.+
+                    type: string
+                required:
+                - base
+                - link
+                - repository
+                type: object
+            required:
+            - configRef
+            - id
+            - jobs
+            - refs
+            type: object
+          status:
+            description: IntegrationJobStatus defines the observed state of IntegrationJob
+            properties:
+              state:
+                description: State is a current state of the IntegrationJob
+                type: string
+            required:
+            - state
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
## Issue
- Unable to apply CRD yamls with following errors   
```
The CustomResourceDefinition "integrationconfigs.cicd.tmax.io" is invalid:
* spec.validation.openAPIV3Schema.properties[spec].properties[jobs].properties[postSubmit].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property
* spec.validation.openAPIV3Schema.properties[spec].properties[jobs].properties[preSubmit].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property
```

## Related upstream issues
- kubernetes-sigs/controller-tools#444

## Solution
- Update controller-gen to v0.4.1, which includes temporary solution kubernetes-sigs/controller-tools#480