### PR TITLE
[fix] Improve scheduler logic

### DIFF
--- a/pkg/pipelinemanager/pipelinemanager.go
+++ b/pkg/pipelinemanager/pipelinemanager.go
@@ -11,3 +11,7 @@ func Generate(_ *cicdv1.IntegrationJob) (*tektonv1beta1.PipelineRun, error) {
 	// TODO
 	return &tektonv1beta1.PipelineRun{}, nil
 }
+
+func Name(j *cicdv1.IntegrationJob) string {
+	return j.Name // TODO - should we add some prefix/suffix...?
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"time"
 )
 
 // Scheduler schedules PipelineRun for IntegrationJob
@@ -34,6 +35,8 @@ type Scheduler struct {
 func (s Scheduler) start() {
 	for range s.caller {
 		s.fifo()
+		// Set minimum time gap between scheduling logic
+		time.Sleep(3 * time.Second)
 	}
 }
 


### PR DESCRIPTION
- Check if 'running' jobs are actually running, inside scheduler
- Remove patching logic for IntegrationJob after scheduling, because
  there would be no timing skew with the explicit running-check logic
- Add secondary order policy (alphanumerical) for sorting pending jobs
- Add minimum time gap between two scheduling events

- Mainly part of #8 
- Also affects #9 