### PR TITLE
[fix] Modify scheduling logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tmax-cloud/cicd-operator
 go 1.13
 
 require (
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/go-logr/logr v0.1.0
 	github.com/gorilla/mux v1.7.4
 	github.com/onsi/ginkgo v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,7 @@ github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAw
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
@@ -686,12 +687,14 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/pkg/scheduler/fifo.go
+++ b/pkg/scheduler/fifo.go
@@ -1,129 +1,20 @@
 package scheduler
 
 import (
-	"context"
 	"fmt"
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
-	"github.com/tmax-cloud/cicd-operator/internal/configs"
-	"github.com/tmax-cloud/cicd-operator/pkg/pipelinemanager"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sort"
+	"github.com/tmax-cloud/cicd-operator/pkg/scheduler/pool"
+	"github.com/tmax-cloud/cicd-operator/pkg/structs"
 )
 
-// fifo is a FIFO scheduler
-func (s Scheduler) fifo() {
-	// List all IntegrationJobs
-	jobList := &cicdv1.IntegrationJobList{}
-	if err := s.k8sClient.List(context.TODO(), jobList); err != nil {
-		log.Error(err, "")
-		return
+func fifoCompare(_a, _b structs.Item) bool {
+	if _a == nil || _b == nil {
+		return false
+	}
+	a, aOk := _a.(*pool.JobNode)
+	b, bOk := _b.(*pool.JobNode)
+	if !aOk || !bOk {
+		return false
 	}
 
-	// Get running jobs first
-	runningJobs := filter(jobList.Items, cicdv1.IntegrationJobStateRunning)
-
-	availableCnt := configs.MaxPipelineRun - len(runningJobs)
-
-	// Check if running jobs are actually running (has pipelineRun, pipelineRun is running)
-	for _, j := range runningJobs {
-		pr := &tektonv1beta1.PipelineRun{}
-		err := s.k8sClient.Get(context.TODO(), types.NamespacedName{Name: pipelinemanager.Name(&j), Namespace: j.Namespace}, pr)
-		// If PipelineRun is not found or is already completed, is not actually running
-		if (err != nil && errors.IsNotFound(err)) || (err == nil && pr.Status.CompletionTime != nil) {
-			availableCnt++
-		}
-	}
-
-	// If the number of running jobs is greater or equals to the max pipeline run, no scheduling is allowed
-	if availableCnt <= 0 {
-		log.Info("Max number of PipelineRuns already exist")
-		return
-	}
-
-	// Now schedule pending jobs
-	pendingJobs := filter(jobList.Items, cicdv1.IntegrationJobStatePending)
-
-	// Sort it as FIFO
-	sort.Sort(jobListFifo(pendingJobs))
-
-	for _, j := range pendingJobs {
-		// Break when max number of running IntegrationJobs exist
-		if availableCnt <= 0 {
-			break
-		}
-
-		// Generate and create PipelineRun
-		pr, err := pipelinemanager.Generate(&j)
-		if err != nil {
-			// TODO - update IntegrationJob status - reason: cannot generate PipelineRun
-			log.Error(err, "")
-			continue
-		}
-		if err := controllerutil.SetControllerReference(&j, pr, s.scheme); err != nil {
-			// TODO - update IntegrationJob status - reason: cannot create PipelineRun
-			log.Error(err, "")
-			continue
-		}
-
-		// Check if PipelineRun already exists
-		if err := s.k8sClient.Get(context.TODO(), types.NamespacedName{Name: pr.Name, Namespace: pr.Namespace}, pr); err != nil {
-			// Not found error is expected
-			if !errors.IsNotFound(err) {
-				// TODO - update IntegrationJob status - reason: cannot get PipelineRun
-				log.Error(err, "")
-				continue
-			}
-		} else {
-			// PipelineRun already exists...
-			availableCnt--
-			continue
-		}
-
-		log.Info(fmt.Sprintf("Scheduled %s / %s / %s", j.Name, j.Namespace, j.CreationTimestamp))
-		// Create PipelineRun only when there is no Pipeline exists
-		if err := s.k8sClient.Create(context.TODO(), pr); err != nil {
-			// TODO - update IntegrationJob status - reason: cannot create PipelineRun
-			log.Error(err, "")
-			continue
-		}
-
-		availableCnt--
-	}
-}
-
-// filter jobs with specific state
-func filter(from []cicdv1.IntegrationJob, state cicdv1.IntegrationJobState) []cicdv1.IntegrationJob {
-	var to []cicdv1.IntegrationJob
-	for _, j := range from {
-		if j.Status.State == state {
-			to = append(to, j)
-		}
-	}
-	return to
-}
-
-// FIFO sorter for IntegrationJob
-type jobListFifo []cicdv1.IntegrationJob
-
-func (j jobListFifo) Len() int {
-	return len(j)
-}
-
-func (j jobListFifo) Swap(x, y int) {
-	j[x], j[y] = j[y], j[x]
-}
-
-func (j jobListFifo) Less(x, y int) bool {
-	xTime := j[x].CreationTimestamp.Time
-	yTime := j[y].CreationTimestamp.Time
-	// Secondary order is alphanumerical
-	if xTime.Equal(yTime) {
-		return j[x].Namespace+"-"+j[x].Name < j[y].Namespace+"-"+j[y].Name
-	} else {
-		// Primary order is time-based
-		return xTime.Before(yTime)
-	}
+	return a.CreationTimestamp.Time.Before(b.CreationTimestamp.Time) || fmt.Sprintf("%s_%s", a.Namespace, a.Name) < fmt.Sprintf("%s_%s", b.Namespace, b.Name)
 }

--- a/pkg/scheduler/pool/pool.go
+++ b/pkg/scheduler/pool/pool.go
@@ -1,0 +1,147 @@
+package pool
+
+import (
+	"fmt"
+	v1 "github.com/tmax-cloud/cicd-operator/api/v1"
+	"github.com/tmax-cloud/cicd-operator/pkg/structs"
+	"sync"
+)
+
+// JobPool stores current status of v1.IntegrationJobs, who are in Pending status or Running status
+// All operations for this pool should be done in thread-safe manner, using Lock and Unlock methods
+type JobPool struct {
+	jobMap jobMap
+
+	Pending *structs.SortedUniqueList
+	Running *structs.SortedUniqueList
+
+	scheduleChan chan struct{}
+	lock         sync.Mutex
+}
+
+func NewJobPool(ch chan struct{}, compareFunc structs.CompareFunc) *JobPool {
+	return &JobPool{
+		jobMap:       jobMap{},
+		Pending:      structs.NewSortedUniqueQueue(compareFunc),
+		Running:      structs.NewSortedUniqueQueue(nil),
+		scheduleChan: ch,
+		lock:         sync.Mutex{},
+	}
+}
+
+func (j *JobPool) Lock() {
+	j.lock.Lock()
+}
+
+func (j *JobPool) Unlock() {
+	j.lock.Unlock()
+}
+
+func (j *JobPool) SyncJob(job *v1.IntegrationJob) {
+	// If job state is not set, return
+	if job.Status.State == "" {
+		return
+	}
+
+	nodeId := getNodeID(job)
+
+	oldStatus := v1.IntegrationJobState("")
+	newStatus := job.Status.State
+
+	// Make / fetch node pointer
+	var node *JobNode
+	candidate, exist := j.jobMap[nodeId]
+	if exist {
+		node = candidate
+		oldStatus = candidate.Status.State
+		candidate.IntegrationJob = job.DeepCopy()
+	} else {
+		node = &JobNode{
+			IntegrationJob: job.DeepCopy(),
+		}
+	}
+	j.jobMap[nodeId] = node
+
+	// If status is not changed, do nothing
+	if exist && oldStatus == newStatus {
+		return
+	}
+
+	// If it is newly created, put it in proper list
+	if !exist {
+		switch newStatus {
+		case v1.IntegrationJobStatePending:
+			j.Pending.Add(node)
+		case v1.IntegrationJobStateRunning:
+			j.Running.Add(node)
+		}
+		j.sendSchedule()
+		return
+	}
+
+	// If there's deletion timestamp, dismiss it
+	if node.DeletionTimestamp != nil {
+		j.Pending.Delete(node)
+		j.Running.Delete(node)
+		delete(j.jobMap, nodeId)
+		j.sendSchedule()
+		return
+	}
+
+	// Pending -> Running
+	if oldStatus == v1.IntegrationJobStatePending {
+		j.Pending.Delete(node)
+		if newStatus == v1.IntegrationJobStateRunning {
+			j.Running.Add(node)
+		}
+		return
+	}
+
+	// Running -> The others
+	// If it WAS running and not now, dismiss it (it is completed for some reason)
+	if oldStatus == v1.IntegrationJobStateRunning {
+		j.Running.Delete(node)
+		// TODO : do we need to handle Running -> Pending ??? might not happen...
+		if newStatus == v1.IntegrationJobStatePending {
+			j.Pending.Add(node)
+		} else {
+			delete(j.jobMap, nodeId)
+		}
+		j.sendSchedule()
+		return
+	}
+}
+
+func (j *JobPool) sendSchedule() {
+	if len(j.scheduleChan) < cap(j.scheduleChan) {
+		j.scheduleChan <- struct{}{}
+	}
+}
+
+// JobNode is a node to be stored in jobMap and JobPool
+type JobNode struct {
+	*v1.IntegrationJob
+}
+
+func (f *JobNode) Equals(another structs.Item) bool {
+	fj, ok := another.(*JobNode)
+	if !ok {
+		return false
+	}
+	if f == nil || fj == nil {
+		return false
+	}
+	return f.Name == fj.Name && f.Namespace == fj.Namespace
+}
+
+func (f *JobNode) DeepCopy() structs.Item {
+	return &JobNode{
+		IntegrationJob: f.IntegrationJob.DeepCopy(),
+	}
+}
+
+func getNodeID(j *v1.IntegrationJob) string {
+	return fmt.Sprintf("%s_%s", j.Namespace, j.Name)
+}
+
+type jobMap map[string]*JobNode

--- a/pkg/scheduler/pool/pool_test.go
+++ b/pkg/scheduler/pool/pool_test.go
@@ -1,0 +1,75 @@
+package pool
+
+import (
+	"fmt"
+	"github.com/bmizerany/assert"
+	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
+	"github.com/tmax-cloud/cicd-operator/pkg/structs"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+	"time"
+)
+
+func TestJobPool_SyncJob(t *testing.T) {
+	ch := make(chan struct{}, 1)
+	p := NewJobPool(ch, testCompare)
+
+	now := time.Now()
+	testJob1 := jobForTest("1", "default", now)
+	testJob2 := jobForTest("2", "default", now)
+	testJob3 := jobForTest("3", "default", now)
+	testJob4 := jobForTest("4", "default", now)
+	testJob5 := jobForTest("5", "default", now)
+	testJob6 := jobForTest("6", "default", now)
+	testJob7 := jobForTest("6", "l2c-system", now)
+
+	p.SyncJob(testJob1)
+	p.SyncJob(testJob2)
+	p.SyncJob(testJob3)
+	p.SyncJob(testJob4)
+	p.SyncJob(testJob5)
+	p.SyncJob(testJob6)
+	p.SyncJob(testJob7)
+
+	// Initial
+	assert.Equal(t, 7, p.Pending.Len(), "state transition isn't done properly")
+	assert.Equal(t, 0, p.Running.Len(), "state transition isn't done properly")
+
+	// 3 Running
+	testJob3.Status.State = cicdv1.IntegrationJobStateRunning
+	p.SyncJob(testJob3)
+	assert.Equal(t, 6, p.Pending.Len(), "state transition isn't done properly")
+	assert.Equal(t, 1, p.Running.Len(), "state transition isn't done properly")
+
+	// 3 Completed
+	testJob3.Status.State = cicdv1.IntegrationJobStateCompleted
+	p.SyncJob(testJob3)
+	assert.Equal(t, 6, p.Pending.Len(), "state transition isn't done properly")
+	assert.Equal(t, 0, p.Running.Len(), "state transition isn't done properly")
+}
+
+func testCompare(_a, _b structs.Item) bool {
+	if _a == nil || _b == nil {
+		return false
+	}
+	a, aOk := _a.(*JobNode)
+	b, bOk := _b.(*JobNode)
+	if !aOk || !bOk {
+		return false
+	}
+
+	return a.CreationTimestamp.Time.Before(b.CreationTimestamp.Time) || fmt.Sprintf("%s_%s", a.Namespace, a.Name) < fmt.Sprintf("%s_%s", b.Namespace, b.Name)
+}
+
+func jobForTest(name, namespace string, created time.Time) *cicdv1.IntegrationJob {
+	return &cicdv1.IntegrationJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.Time{Time: created},
+		},
+		Status: cicdv1.IntegrationJobStatus{
+			State: cicdv1.IntegrationJobStatePending,
+		},
+	}
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,8 +1,19 @@
 package scheduler
 
 import (
+	"context"
+	"fmt"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
+	"github.com/tmax-cloud/cicd-operator/internal/configs"
+	"github.com/tmax-cloud/cicd-operator/pkg/pipelinemanager"
+	"github.com/tmax-cloud/cicd-operator/pkg/scheduler/pool"
+	"github.com/tmax-cloud/cicd-operator/pkg/structs"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"time"
 )
@@ -16,8 +27,9 @@ func New(c client.Client, s *runtime.Scheme) *Scheduler {
 	sch := &Scheduler{
 		k8sClient: c,
 		scheme:    s,
-		caller:    make(chan int, 1),
+		caller:    make(chan struct{}, 1),
 	}
+	sch.jobPool = pool.NewJobPool(sch.caller, fifoCompare) // TODO : compare function should be configurable
 	go sch.start()
 	return sch
 }
@@ -26,27 +38,99 @@ type Scheduler struct {
 	k8sClient client.Client
 	scheme    *runtime.Scheme
 
+	jobPool *pool.JobPool
+
 	// Buffered channel with capacity 1
 	// Since scheduler lists resources by itself, the actual scheduling logic should be executed only once even when
 	// Schedule is called for several times
-	caller chan int
+	caller chan struct{}
+}
+
+func (s Scheduler) Notify(job *cicdv1.IntegrationJob) {
+	s.jobPool.Lock()
+	s.jobPool.SyncJob(job)
+	s.jobPool.Unlock()
 }
 
 func (s Scheduler) start() {
 	for range s.caller {
-		s.fifo()
+		s.run()
 		// Set minimum time gap between scheduling logic
 		time.Sleep(3 * time.Second)
 	}
 }
 
-// Schedule is an exported function, which is called from the other packages
-// It just enqueues a 'schedule job'
-func (s Scheduler) Schedule() {
-	log.Info("Schedule")
-	// Exit if channel buffer is full
-	if len(s.caller) == cap(s.caller) {
+func (s Scheduler) run() {
+	s.jobPool.Lock()
+	defer s.jobPool.Unlock()
+	log.Info("scheduling...")
+	availableCnt := configs.MaxPipelineRun - s.jobPool.Running.Len()
+
+	// Check if running jobs are actually running (has pipelineRun, pipelineRun is running)
+	s.jobPool.Running.ForEach(func(item structs.Item) {
+		j, ok := item.(*pool.JobNode)
+		if !ok {
+			return
+		}
+		pr := &tektonv1beta1.PipelineRun{}
+		err := s.k8sClient.Get(context.TODO(), types.NamespacedName{Name: pipelinemanager.Name(j.IntegrationJob), Namespace: j.Namespace}, pr)
+		// If PipelineRun is not found or is already completed, is not actually running
+		if (err != nil && errors.IsNotFound(err)) || (err == nil && pr.Status.CompletionTime != nil) {
+			availableCnt++
+		}
+	})
+
+	// If the number of running jobs is greater or equals to the max pipeline run, no scheduling is allowed
+	if availableCnt <= 0 {
+		log.Info("Max number of PipelineRuns already exist")
 		return
 	}
-	s.caller <- 1
+
+	// Schedule if available
+	s.jobPool.Pending.ForEach(func(item structs.Item) {
+		if availableCnt <= 0 {
+			return
+		}
+		jobNode, ok := item.(*pool.JobNode)
+		if !ok {
+			return
+		}
+
+		// Check if PipelineRun already exists
+		testPr := &tektonv1beta1.PipelineRun{}
+		if err := s.k8sClient.Get(context.TODO(), types.NamespacedName{Name: pipelinemanager.Name(jobNode.IntegrationJob), Namespace: jobNode.Namespace}, testPr); err != nil {
+			// Not found error is expected
+			if !errors.IsNotFound(err) {
+				log.Error(err, "")
+				return
+			}
+		} else {
+			// PipelineRun already exists...
+			availableCnt--
+			return
+		}
+
+		// Generate and create PipelineRun
+		pr, err := pipelinemanager.Generate(jobNode.IntegrationJob)
+		if err != nil {
+			// TODO - update IntegrationJob status - reason: cannot generate PipelineRun
+			log.Error(err, "")
+			return
+		}
+		if err := controllerutil.SetControllerReference(jobNode.IntegrationJob, pr, s.scheme); err != nil {
+			// TODO - update IntegrationJob status - reason: cannot create PipelineRun
+			log.Error(err, "")
+			return
+		}
+
+		log.Info(fmt.Sprintf("Scheduled %s / %s / %s", jobNode.Name, jobNode.Namespace, jobNode.CreationTimestamp))
+		// Create PipelineRun only when there is no Pipeline exists
+		if err := s.k8sClient.Create(context.TODO(), pr); err != nil {
+			// TODO - update IntegrationJob status - reason: cannot create PipelineRun
+			log.Error(err, "")
+			return
+		}
+
+		availableCnt--
+	})
 }

--- a/pkg/structs/queue.go
+++ b/pkg/structs/queue.go
@@ -1,0 +1,136 @@
+package structs
+
+import (
+	"sync"
+)
+
+type Item interface {
+	DeepCopy() Item
+	Equals(Item) bool
+}
+
+type node struct {
+	item Item
+
+	prev *node
+	next *node
+}
+
+func newNode(item Item) *node {
+	return &node{item: item.DeepCopy()}
+}
+
+type CompareFunc func(a Item, b Item) bool
+
+type SortedUniqueList struct {
+	nodes *node
+	lock  sync.Mutex
+
+	compareFunc CompareFunc
+}
+
+func (q *SortedUniqueList) Add(item Item) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	var prevPtr *node
+	nextPtr := q.nodes
+
+	if q.compareFunc != nil {
+		for nextPtr != nil {
+			// Sort
+			if q.compareFunc(item, nextPtr.item) {
+				break
+			}
+			prevPtr = nextPtr
+			nextPtr = nextPtr.next
+		}
+	}
+
+	if prevPtr != nil {
+		// Guarantee uniqueness
+		if item.Equals(prevPtr.item) {
+			return
+		}
+	}
+
+	if nextPtr != nil {
+		// Guarantee uniqueness
+		if item.Equals(nextPtr.item) {
+			return
+		}
+	}
+
+	n := newNode(item)
+	n.next = nextPtr
+	n.prev = prevPtr
+	if nextPtr != nil {
+		nextPtr.prev = n
+	}
+	if prevPtr != nil {
+		prevPtr.next = n
+	} else {
+		q.nodes = n
+	}
+}
+
+func (q *SortedUniqueList) First() Item {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	n := q.nodes
+
+	if n == nil {
+		return nil
+	}
+
+	return n.item
+}
+
+type IteratorFunc func(Item)
+
+func (q *SortedUniqueList) ForEach(iteratorFunc IteratorFunc) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	n := q.nodes
+
+	for n != nil {
+		iteratorFunc(n.item)
+		n = n.next
+	}
+}
+
+func (q *SortedUniqueList) Delete(i Item) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	n := q.nodes
+
+	for n != nil {
+		if n.item.Equals(i) {
+			if n.next != nil {
+				n.next.prev = n.prev
+			}
+			if n.prev != nil {
+				n.prev.next = n.next
+			} else {
+				q.nodes = n.next
+			}
+			return
+		}
+		n = n.next
+	}
+}
+
+func (q *SortedUniqueList) Len() int {
+	i := 0
+	q.ForEach(func(_ Item) {
+		i++
+	})
+	return i
+}
+
+func NewSortedUniqueQueue(compareFunc CompareFunc) *SortedUniqueList {
+	return &SortedUniqueList{lock: sync.Mutex{}, compareFunc: compareFunc}
+}

--- a/pkg/structs/queue_test.go
+++ b/pkg/structs/queue_test.go
@@ -1,0 +1,128 @@
+package structs
+
+import (
+	"github.com/bmizerany/assert"
+	"testing"
+)
+
+type testType struct {
+	body int
+}
+
+func (t *testType) DeepCopy() Item {
+	if t == nil {
+		return nil
+	}
+	return &testType{body: t.body}
+}
+
+func (t *testType) Equals(another Item) bool {
+	if t == nil || another == nil {
+		return false
+	}
+	b, ok := another.(*testType)
+	if !ok {
+		return false
+	}
+	return t.body == b.body
+}
+
+func compare(_a, _b Item) bool {
+	if _a == nil || _b == nil {
+		return false
+	}
+	a, aOk := _a.(*testType)
+	b, bOk := _b.(*testType)
+	if !aOk || !bOk {
+		return false
+	}
+	return a.body < b.body
+}
+
+func initQueue() *SortedUniqueList {
+	q := NewSortedUniqueQueue(compare)
+	q.Add(&testType{body: 2})
+	q.Add(&testType{body: 3})
+	q.Add(&testType{body: 3})
+	q.Add(&testType{body: 7})
+	q.Add(&testType{body: 6})
+	q.Add(&testType{body: 4})
+	q.Add(&testType{body: 1})
+	q.Add(&testType{body: 2})
+	q.Add(&testType{body: 2})
+	q.Add(&testType{body: 5})
+	q.Add(&testType{body: 5})
+	q.Add(&testType{body: 3})
+	q.Add(&testType{body: 5})
+
+	return q
+}
+
+func TestSortedUniqueQueue_Put(t *testing.T) {
+	q := initQueue()
+
+	n := q.nodes
+
+	if n == nil {
+		t.Fatal("nodes are nil")
+	}
+
+	i := 0
+	for n != nil {
+		it, ok := n.item.(*testType)
+		assert.Equal(t, true, ok, "item is not a testType")
+		assert.Equal(t, i+1, it.body, "items are not sorted")
+		n = n.next
+		i++
+	}
+}
+
+func TestSortedUniqueList_First(t *testing.T) {
+	q := initQueue()
+	f := q.First()
+	if f == nil {
+		t.Fatal("first is nil")
+	}
+
+	ff, ok := f.(*testType)
+	assert.Equal(t, true, ok, "item is not a testType")
+	assert.Equal(t, 1, ff.body, "item is not sorted")
+}
+
+func TestSortedUniqueList_Delete(t *testing.T) {
+	q := initQueue()
+
+	var i *testType
+
+	f := q.First()
+	if f == nil {
+		t.Fatal("first is nil")
+	}
+	ff, ok := f.(*testType)
+	assert.Equal(t, true, ok, "item is not a testType")
+	assert.Equal(t, 1, ff.body, "item is not sorted")
+
+	i = &testType{body: 1}
+	q.Delete(i)
+
+	f = q.First()
+	if f == nil {
+		t.Fatal("first is nil")
+	}
+	ff, ok = f.(*testType)
+	assert.Equal(t, true, ok, "item is not a testType")
+	assert.Equal(t, 2, ff.body, "item is not deleted")
+}
+
+func TestSortedUniqueList_ForEach(t *testing.T) {
+	q := initQueue()
+
+	i := 1
+	q.ForEach(func(item Item) {
+		it, ok := item.(*testType)
+		assert.Equal(t, true, ok, "item is not a testType")
+
+		assert.Equal(t, i, it.body, "item is not looped correctly")
+		i++
+	})
+}


### PR DESCRIPTION
Added JobPool, which is a kind of in-memory cache for IntegrationJobs,
in status of pending or running.
This JobPool is synced whenever the status of IntegrationJobs change.

Scheduling logic is called for only three following cases.
1. New IntegrationJob is generated
2. Existing IntegrationJob is deleted
3. Running IntegrationJob is completed/failed

Then the scheduler reads the pool and creates new PipelineRun when there
exists fewer PipelineRuns than the maximum number.

#8 #14