### PR TITLE
[fix] Fix to use full_name rather than name for repository name

### DIFF
--- a/pkg/git/github/webhook.go
+++ b/pkg/git/github/webhook.go
@@ -28,7 +28,7 @@ type PushWebhook struct {
 
 // Repo structure for webhook event
 type Repo struct {
-	Name    string `json:"name"`
+	Name    string `json:"full_name"`
 	Htmlurl string `json:"html_url"`
 	Owner   struct {
 		ID string `json:"login"`


### PR DESCRIPTION
- Current
  * Repository name is `cicd-operator` for `cqbqdd11519/cicd-operator`
- Fixed
  * Repository name is `cqbqdd11519/cicd-operator` for `cqbqdd11519/cicd-operator`